### PR TITLE
Refine coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,28 @@
+name: Code Coverage
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.14.0'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Run tests with coverage
+        run: npm run test:coverage
+
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@v2
+

--- a/.github/workflows/deploy-front.yml
+++ b/.github/workflows/deploy-front.yml
@@ -37,11 +37,6 @@ jobs:
       - name: Run tests with coverage
         run: npm run test:coverage
 
-      # Upload coverage to Coveralls
-      - name: Upload coverage to Coveralls
-        uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Generate a unique build ID based on timestamp and commit hash
       - name: Generate build ID


### PR DESCRIPTION
## Summary
- avoid Coveralls duplicate reports by removing token and artifact step in coverage workflow
- drop Coveralls upload from frontend deploy workflow

## Testing
- `npm run test:coverage`
