### PR TITLE
Remove eval command and eval channel functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "core-js": "^3.33.0",
         "express": "^4.18.2",
         "groq-sdk": "^0.33.0",
-        "node-fetch": "^3.3.2",
         "pg": "^8.16.3",
         "socket.io": "^4.7.2",
         "socket.io-client": "^4.8.1",
@@ -6443,15 +6442,6 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/data-urls": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
@@ -8141,29 +8131,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -8406,18 +8373,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/formidable": {
@@ -11981,24 +11936,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-forge": {
@@ -16619,15 +16556,6 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/server.js
+++ b/server.js
@@ -21,21 +21,7 @@ const io = socketIo(server, {
 });
 
 // Define available channels
-const CHANNELS = ['general', 'eval', 'feedback'];
-
-// Eval questions for LLM evaluation
-const EVAL_QUESTIONS = [
-  { q: "What is the capital of Australia?", a: "Canberra" },
-  { q: "What is 17 × 23?", a: "391" },
-  { q: "Complete the sequence: 2, 6, 12, 20, 30, ?", a: "42" },
-  { q: "What does HTML stand for?", a: "HyperText Markup Language" },
-  { q: "If all roses are flowers and some flowers fade quickly, can we conclude that some roses fade quickly?", a: "No" },
-  { q: "What is the output of: [1,2,3].map(x => x * 2).filter(x => x > 2)", a: "[4, 6]" },
-  { q: "A bat and ball cost $1.10 total. The bat costs $1 more than the ball. How much does the ball cost?", a: "$0.05" },
-  { q: "How many days are in a leap year?", a: "366" },
-  { q: "How many r's are in the word strawberry?", a: "3" },
-  { q: "Is this valid JSON? {\"name\": \"test\", \"count\": 5,}", a: "No" }
-];
+const CHANNELS = ['general', 'feedback'];
 
 // Database connection pool
 const pool = new Pool({
@@ -239,96 +225,6 @@ function setupSocketHandlers(io) {
         });
       } catch (error) {
         console.error('Error saving username change to database:', error);
-      }
-    });
-
-    // Handle @eval command
-    socket.on('eval_command', async (data) => {
-      const { username: evalUser, channel } = data;
-
-      // Only allow in #eval channel
-      if (channel !== 'eval') {
-        socket.emit('chat_message', {
-          timestamp: new Date().toISOString(),
-          username: 'System',
-          message: 'The @eval command can only be used in the #eval channel.',
-          channel: channel
-        });
-        return;
-      }
-
-      // Announce eval start
-      const startTimestamp = new Date().toISOString();
-      const startMessage = `${evalUser} started an LLM evaluation...`;
-
-      await pool.query(
-        'INSERT INTO messages (timestamp, username, message, channel) VALUES ($1, $2, $3, $4)',
-        [startTimestamp, 'System', startMessage, 'eval']
-      );
-
-      io.emit('chat_message', {
-        timestamp: startTimestamp,
-        username: 'System',
-        message: startMessage,
-        channel: 'eval'
-      });
-
-      let passed = 0;
-      const results = [];
-
-      try {
-        for (const { q, a } of EVAL_QUESTIONS) {
-          const completion = await groq.chat.completions.create({
-            messages: [
-              { role: 'system', content: 'Answer concisely in as few words as possible. Just give the answer, no explanation.' },
-              { role: 'user', content: q }
-            ],
-            model: "openai/gpt-oss-20b",
-            temperature: 0,
-            max_completion_tokens: 100
-          });
-
-          const aiAnswer = completion.choices[0]?.message?.content?.trim() || '';
-          const isCorrect = aiAnswer.toLowerCase().includes(a.toLowerCase());
-
-          if (isCorrect) passed++;
-          results.push({ q, expected: a, got: aiAnswer, pass: isCorrect });
-        }
-
-        // Format and send results
-        const resultLines = results.map((r, i) =>
-          `${r.pass ? 'PASS' : 'FAIL'} Q${i + 1}: ${r.q}\n   Expected: ${r.expected} | Got: ${r.got}`
-        );
-        const resultMessage = resultLines.join('\n\n') + `\n\nScore: ${passed}/10`;
-        const resultTimestamp = new Date().toISOString();
-
-        await pool.query(
-          'INSERT INTO messages (timestamp, username, message, channel) VALUES ($1, $2, $3, $4)',
-          [resultTimestamp, 'System', resultMessage, 'eval']
-        );
-
-        io.emit('chat_message', {
-          timestamp: resultTimestamp,
-          username: 'System',
-          message: resultMessage,
-          channel: 'eval'
-        });
-      } catch (error) {
-        console.error('Error running eval:', error);
-        const errorTimestamp = new Date().toISOString();
-        const errorMessage = 'Error running evaluation. Please try again.';
-
-        await pool.query(
-          'INSERT INTO messages (timestamp, username, message, channel) VALUES ($1, $2, $3, $4)',
-          [errorTimestamp, 'System', errorMessage, 'eval']
-        );
-
-        io.emit('chat_message', {
-          timestamp: errorTimestamp,
-          username: 'System',
-          message: errorMessage,
-          channel: 'eval'
-        });
       }
     });
 

--- a/src/components/ChatContent.vue
+++ b/src/components/ChatContent.vue
@@ -88,7 +88,6 @@ export default {
     channelDescription() {
       const descriptions = {
         general: 'Main discussion area for our self-improving chat application.',
-        eval: 'Evaluation and testing channel for AI model experiments.',
         feedback: 'Share your thoughts and suggestions about the app here.'
       };
       return descriptions[this.currentChannel] || 'Channel description';
@@ -231,24 +230,6 @@ export default {
       
       if (!this.isConnected) {
         // Optionally, you could add a notification here that the message can't be sent
-        return;
-      }
-
-      // Check for @eval command
-      if (this.newMessage.trim() === '@eval') {
-        if (this.localChannel !== 'eval') {
-          this.messages.push({
-            timestamp: new Date().toISOString(),
-            username: 'System',
-            message: 'The @eval command can only be used in the #eval channel.'
-          });
-        } else {
-          this.socket.emit('eval_command', {
-            username: this.localUsername,
-            channel: this.localChannel
-          });
-        }
-        this.newMessage = '';
         return;
       }
 

--- a/src/components/ChatLayout.vue
+++ b/src/components/ChatLayout.vue
@@ -62,7 +62,6 @@ export default {
       isFirstJoin: isFirstJoin,
       channelUnreadCounts: {
         general: 0,
-        eval: 0,
         feedback: 0
       }
     }

--- a/src/components/MainSidebar.vue
+++ b/src/components/MainSidebar.vue
@@ -70,7 +70,6 @@ export default {
       type: Object,
       default: () => ({
         general: 0,
-        eval: 0,
         feedback: 0
       })
     }
@@ -78,7 +77,7 @@ export default {
   data() {
     return {
       showChannels: true,
-      channels: ['general', 'eval', 'feedback']
+      channels: ['general', 'feedback']
     }
   },
   computed: {

--- a/tests/ChatContent.test.js
+++ b/tests/ChatContent.test.js
@@ -406,46 +406,6 @@ describe('ChatContent.vue', () => {
     expect(wrapper.vm.newMessage).toBe('');
   });
 
-  test('sendMessage handles @eval command in eval channel', () => {
-    wrapper.setData({
-      isConnected: true,
-      newMessage: '@eval',
-      localChannel: 'eval'
-    });
-
-    wrapper.vm.sendMessage();
-
-    // Verify eval_command was emitted to socket
-    expect(mockSocketEmit).toHaveBeenCalledWith('eval_command', {
-      username: 'testuser',
-      channel: 'eval'
-    });
-
-    // Verify input was cleared
-    expect(wrapper.vm.newMessage).toBe('');
-  });
-
-  test('sendMessage rejects @eval command outside eval channel', () => {
-    wrapper.setData({
-      isConnected: true,
-      newMessage: '@eval',
-      localChannel: 'general'
-    });
-
-    wrapper.vm.sendMessage();
-
-    // Verify eval_command was NOT emitted to socket
-    expect(mockSocketEmit).not.toHaveBeenCalledWith('eval_command', expect.anything());
-
-    // Verify system message was added locally
-    expect(wrapper.vm.messages).toHaveLength(1);
-    expect(wrapper.vm.messages[0].username).toBe('System');
-    expect(wrapper.vm.messages[0].message).toBe('The @eval command can only be used in the #eval channel.');
-
-    // Verify input was cleared
-    expect(wrapper.vm.newMessage).toBe('');
-  });
-
   test('formatTimestamp converts timestamps correctly', () => {
     // Test a valid timestamp
     const timestamp = '2023-01-01T14:30:00Z';

--- a/tests/MainSidebar.test.js
+++ b/tests/MainSidebar.test.js
@@ -131,7 +131,6 @@ describe('MainSidebar.vue', () => {
     });
     expect(wrapper.vm.channelUnreadCounts).toEqual({
       general: 0,
-      eval: 0,
       feedback: 0
     });
   });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -5,8 +5,6 @@ const io = require('socket.io-client');
 // Flag to control AI response behavior (must be prefixed with 'mock' for Jest)
 let mockShouldReturnEmptyAiResponse = false;
 let mockShouldThrowError = false;
-let mockEvalCorrectAnswer = null;
-
 // Mock Groq SDK
 jest.mock('groq-sdk', () => ({
   Groq: jest.fn().mockImplementation(() => ({
@@ -19,11 +17,6 @@ jest.mock('groq-sdk', () => ({
           if (mockShouldReturnEmptyAiResponse) {
             return Promise.resolve({
               choices: [{ message: { content: null } }]
-            });
-          }
-          if (mockEvalCorrectAnswer) {
-            return Promise.resolve({
-              choices: [{ message: { content: mockEvalCorrectAnswer } }]
             });
           }
           return Promise.resolve({
@@ -178,8 +171,6 @@ describe('Server Module - Comprehensive', () => {
           mockSocket.usernameChangeCallback = callback;
         } else if (event === 'join_channel') {
           mockSocket.joinChannelCallback = callback;
-        } else if (event === 'eval_command') {
-          mockSocket.evalCommandCallback = callback;
         }
         return mockSocket;
       }),
@@ -957,177 +948,3 @@ describe('Server Module - Comprehensive', () => {
   });
 });
 
-describe('Server Module - Eval Command', () => {
-  let mockSocket;
-  let mockServer;
-  let originalCreateServer;
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-
-    mockSocket = {
-      on: jest.fn((event, callback) => {
-        if (event === 'eval_command') {
-          mockSocket.evalCommandCallback = callback;
-        }
-        return mockSocket;
-      }),
-      emit: jest.fn(),
-      join: jest.fn(),
-      leave: jest.fn(),
-      to: jest.fn(() => ({
-        emit: jest.fn()
-      }))
-    };
-
-    mockServer = {
-      listen: jest.fn((port, host, callback) => {
-        const cb = typeof host === 'function' ? host : callback;
-        if (cb) cb();
-        return mockServer;
-      })
-    };
-
-    originalCreateServer = http.createServer;
-    http.createServer = jest.fn(() => mockServer);
-
-    jest.isolateModules(() => {
-      require('../server');
-    });
-
-    if (global.socketConnectionCallback) {
-      global.socketConnectionCallback(mockSocket);
-    }
-  });
-
-  afterEach(() => {
-    http.createServer = originalCreateServer;
-    delete global.socketConnectionCallback;
-    mockPool.query.mockClear();
-  });
-
-  test('sets up eval_command event handler', () => {
-    expect(mockSocket.on).toHaveBeenCalledWith('eval_command', expect.any(Function));
-  });
-
-  test('eval_command rejects non-eval channel', async () => {
-    await mockSocket.evalCommandCallback({
-      username: 'TestUser',
-      channel: 'general'
-    });
-
-    expect(mockSocket.emit).toHaveBeenCalledWith('chat_message', expect.objectContaining({
-      username: 'System',
-      message: 'The @eval command can only be used in the #eval channel.',
-      channel: 'general'
-    }));
-  });
-
-  test('eval_command broadcasts start message in eval channel', async () => {
-    await mockSocket.evalCommandCallback({
-      username: 'TestUser',
-      channel: 'eval'
-    });
-
-    expect(mockIO.emit).toHaveBeenCalledWith('chat_message', expect.objectContaining({
-      username: 'System',
-      message: 'TestUser started an LLM evaluation...',
-      channel: 'eval'
-    }));
-  });
-
-  test('eval_command broadcasts results after completion', async () => {
-    await mockSocket.evalCommandCallback({
-      username: 'TestUser',
-      channel: 'eval'
-    });
-
-    // Should have at least 2 emits: start message and results
-    const emitCalls = mockIO.emit.mock.calls.filter(call => call[0] === 'chat_message');
-    expect(emitCalls.length).toBeGreaterThanOrEqual(2);
-
-    // Last emit should contain the score
-    const lastEmit = emitCalls[emitCalls.length - 1];
-    expect(lastEmit[1].message).toContain('Score:');
-    expect(lastEmit[1].message).toContain('/10');
-  });
-
-  test('eval_command runs all 10 questions', async () => {
-    await mockSocket.evalCommandCallback({
-      username: 'TestUser',
-      channel: 'eval'
-    });
-
-    // Check results contain all 10 questions
-    const emitCalls = mockIO.emit.mock.calls.filter(call => call[0] === 'chat_message');
-    const resultsEmit = emitCalls[emitCalls.length - 1];
-
-    expect(resultsEmit[1].message).toContain('Q1:');
-    expect(resultsEmit[1].message).toContain('Q10:');
-    expect(resultsEmit[1].message).toContain('capital of Australia');
-    expect(resultsEmit[1].message).toContain('strawberry');
-  });
-
-  test('eval_command handles AI errors gracefully', async () => {
-    mockShouldThrowError = true;
-    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-
-    await mockSocket.evalCommandCallback({
-      username: 'TestUser',
-      channel: 'eval'
-    });
-
-    // Should emit error message
-    expect(mockIO.emit).toHaveBeenCalledWith('chat_message', expect.objectContaining({
-      username: 'System',
-      message: 'Error running evaluation. Please try again.',
-      channel: 'eval'
-    }));
-
-    expect(consoleErrorSpy).toHaveBeenCalledWith('Error running eval:', expect.any(Error));
-
-    mockShouldThrowError = false;
-    consoleErrorSpy.mockRestore();
-  });
-
-  test('eval_command increments score for correct answers', async () => {
-    // Make the mock return "Canberra" which matches Q1's expected answer
-    mockEvalCorrectAnswer = 'Canberra';
-
-    await mockSocket.evalCommandCallback({
-      username: 'TestUser',
-      channel: 'eval'
-    });
-
-    const emitCalls = mockIO.emit.mock.calls.filter(call => call[0] === 'chat_message');
-    const resultsEmit = emitCalls[emitCalls.length - 1];
-
-    // Should have PASS for Q1 (capital of Australia = Canberra)
-    expect(resultsEmit[1].message).toContain('PASS Q1:');
-    // Score should be 10/10 since all answers contain "Canberra"
-    // (but only Q1 expects it, so actually it should show some passes)
-    expect(resultsEmit[1].message).toMatch(/Score: \d+\/10/);
-
-    mockEvalCorrectAnswer = null;
-  });
-
-  test('eval_command handles empty AI responses', async () => {
-    // Make the mock return empty content
-    mockShouldReturnEmptyAiResponse = true;
-
-    await mockSocket.evalCommandCallback({
-      username: 'TestUser',
-      channel: 'eval'
-    });
-
-    const emitCalls = mockIO.emit.mock.calls.filter(call => call[0] === 'chat_message');
-    const resultsEmit = emitCalls[emitCalls.length - 1];
-
-    // All answers should be empty, so all should fail
-    expect(resultsEmit[1].message).toContain('FAIL Q1:');
-    expect(resultsEmit[1].message).toContain('Got: ');
-    expect(resultsEmit[1].message).toContain('Score: 0/10');
-
-    mockShouldReturnEmptyAiResponse = false;
-  });
-});


### PR DESCRIPTION
## Summary
This PR removes the `@eval` command and the `#eval` channel from the application. The eval feature, which was used to run LLM evaluation tests with a predefined set of 10 questions, has been completely removed from both the backend and frontend.

## Key Changes

**Backend (server.js):**
- Removed `EVAL_QUESTIONS` constant containing 10 test questions
- Removed `'eval'` from the `CHANNELS` list
- Removed the `eval_command` socket event handler that processed evaluation requests and returned scored results

**Frontend (Vue components):**
- Removed `@eval` command handling from `ChatContent.vue`
- Removed eval channel description from channel descriptions
- Removed `'eval'` from the channels list in `MainSidebar.vue`
- Removed eval channel from initial unread counts in `ChatLayout.vue`

**Tests:**
- Removed all eval-related test cases from `server.test.js` (entire "Server Module - Eval Command" test suite)
- Removed eval command tests from `ChatContent.test.js`
- Removed eval channel from mock unread counts in `MainSidebar.test.js`
- Removed mock support for eval responses in the Groq SDK mock

## Implementation Details
The eval feature was a self-contained module that allowed users to trigger LLM evaluation tests in a dedicated channel. Removing it simplifies the codebase by eliminating:
- 10 hardcoded test questions and their expected answers
- Complex answer validation logic with substring matching
- A dedicated socket event handler and its associated tests
- UI elements and routing for the eval channel

The application now supports only two channels: `general` and `feedback`.

https://claude.ai/code/session_01TUdvPSUuAp9ewjaRVEByNR