### PR TITLE
Add welcome and growth channels to chat application

### DIFF
--- a/server.js
+++ b/server.js
@@ -19,7 +19,7 @@ const io = socketIo(server, {
 });
 
 // Define available channels
-const CHANNELS = ['general', 'feedback'];
+const CHANNELS = ['welcome', 'general', 'growth', 'feedback'];
 
 // Database connection pool
 const pool = new Pool({

--- a/src/components/ChatContent.vue
+++ b/src/components/ChatContent.vue
@@ -87,8 +87,10 @@ export default {
   computed: {
     channelDescription() {
       const descriptions = {
-        general: 'Main discussion channel for the community.',
-        feedback: 'Share your thoughts and suggestions here.'
+        welcome: 'Say hi — no account needed.',
+        general: 'Announcements and workspace updates.',
+        growth: 'Outreach, experiments, and new user activity.',
+        feedback: 'Bugs, ideas, and feature requests.'
       };
       return descriptions[this.currentChannel] || 'Channel description';
     }

--- a/src/components/ChatLayout.vue
+++ b/src/components/ChatLayout.vue
@@ -61,7 +61,9 @@ export default {
       currentChannel: savedChannel,
       isFirstJoin: isFirstJoin,
       channelUnreadCounts: {
+        welcome: 0,
         general: 0,
+        growth: 0,
         feedback: 0
       }
     }

--- a/src/components/MainSidebar.vue
+++ b/src/components/MainSidebar.vue
@@ -69,7 +69,9 @@ export default {
     channelUnreadCounts: {
       type: Object,
       default: () => ({
+        welcome: 0,
         general: 0,
+        growth: 0,
         feedback: 0
       })
     }
@@ -77,7 +79,7 @@ export default {
   data() {
     return {
       showChannels: true,
-      channels: ['general', 'feedback']
+      channels: ['welcome', 'general', 'growth', 'feedback']
     }
   },
   computed: {

--- a/src/components/ServerSidebar.vue
+++ b/src/components/ServerSidebar.vue
@@ -33,7 +33,9 @@ export default {
     channelUnreadCounts: {
       type: Object,
       default: () => ({
+        welcome: 0,
         general: 0,
+        growth: 0,
         feedback: 0
       })
     }

--- a/tests/ChatContent.test.js
+++ b/tests/ChatContent.test.js
@@ -781,7 +781,7 @@ describe('ChatContent.vue', () => {
       }
     });
     
-    expect(wrapper.vm.channelDescription).toContain('Main discussion');
+    expect(wrapper.vm.channelDescription).toContain('Announcements, updates, and agent activity.');
   });
   
 

--- a/tests/ChatContent.test.js
+++ b/tests/ChatContent.test.js
@@ -781,7 +781,7 @@ describe('ChatContent.vue', () => {
       }
     });
     
-    expect(wrapper.vm.channelDescription).toContain('Announcements, updates, and agent activity.');
+    expect(wrapper.vm.channelDescription).toContain('Announcements and workspace updates.');
   });
   
 

--- a/tests/MainSidebar.test.js
+++ b/tests/MainSidebar.test.js
@@ -130,7 +130,9 @@ describe('MainSidebar.vue', () => {
       }
     });
     expect(wrapper.vm.channelUnreadCounts).toEqual({
+      welcome: 0,
       general: 0,
+      growth: 0,
       feedback: 0
     });
   });


### PR DESCRIPTION
## Summary
This PR expands the chat application's channel structure by adding two new channels (`welcome` and `growth`) and updating descriptions for existing channels to better reflect their purposes.

## Key Changes
- **New Channels**: Added `welcome` and `growth` channels alongside existing `general` and `feedback` channels
  - `welcome`: For new users to introduce themselves without requiring an account
  - `growth`: For outreach, experiments, and new user activity tracking
- **Updated Channel Descriptions**: Refined descriptions for all channels to be more descriptive and purpose-driven
  - `general`: Changed from "Main discussion channel" to "Announcements and workspace updates"
  - `feedback`: Changed from "Share your thoughts and suggestions" to "Bugs, ideas, and feature requests"
- **Consistent Updates Across Codebase**: Updated channel references in:
  - Frontend components (ChatContent, MainSidebar, ChatLayout, ServerSidebar)
  - Backend server configuration
  - Test files to match new channel structure

## Implementation Details
- Channel list is now defined as `['welcome', 'general', 'growth', 'feedback']` across all components
- Unread count tracking initialized for all four channels with default value of 0
- Channel descriptions mapped in ChatContent component for dynamic display
- All test assertions updated to reflect new channel descriptions and structure

https://claude.ai/code/session_01CkB7zxQ6EUqdoWwGnWpU96