### PR TITLE
Implement sign-in requirement for posting in non-welcome channels

### DIFF
--- a/src/components/ChatLayout.vue
+++ b/src/components/ChatLayout.vue
@@ -21,8 +21,8 @@
     <ChatContent
       :username="username"
       :current-channel="currentChannel"
+      :is-signed-in="isSignedIn"
       @connection-change="handleConnectionStatusChange"
-      @username-change="handleUsernameChange"
       @channel-change="changeChannel"
       @message-received="handleMessageReceived"
       ref="chatContent"

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -23,7 +23,6 @@ const CHANNELS = ['welcome', 'general', 'growth', 'feedback'];
 
 // Validation constants
 const MAX_MESSAGE_LENGTH = 2000;
-const MAX_USERNAME_LENGTH = 30;
 
 // Database connection pool
 const pool = new Pool({
@@ -146,45 +145,6 @@ function setupSocketHandlers(io) {
       } catch (error) {
         console.error('Error saving message to database:', error);
         socket.emit('error', { message: 'Failed to save message' });
-      }
-    });
-
-    // Handle username changes
-    socket.on('username_change', async (data) => {
-      // Validate new username
-      if (!data.newUsername || typeof data.newUsername !== 'string' || data.newUsername.trim() === '') {
-        socket.emit('error', { message: 'Username cannot be empty' });
-        return;
-      }
-      if (data.newUsername.length > MAX_USERNAME_LENGTH) {
-        socket.emit('error', { message: `Username exceeds maximum length of ${MAX_USERNAME_LENGTH} characters` });
-        return;
-      }
-
-      // Update the username for this socket
-      username = data.newUsername;
-
-      // Log the username change as a system message to the specified channel
-      const timestamp = new Date().toISOString();
-      const channel = data.channel || 'general';
-      const systemMessage = `${data.oldUsername} changed their username to ${data.newUsername}`;
-
-      // Save system message to database
-      try {
-        await pool.query(
-          'INSERT INTO messages (timestamp, username, message, channel) VALUES ($1, $2, $3, $4)',
-          [timestamp, 'System', systemMessage, channel]
-        );
-
-        // Broadcast to all clients in the channel except the sender
-        socket.to(channel).emit('chat_message', {
-          timestamp,
-          username: 'System',
-          message: systemMessage,
-          channel: channel
-        });
-      } catch (error) {
-        console.error('Error saving username change to database:', error);
       }
     });
 

--- a/tests/ChatLayout.test.js
+++ b/tests/ChatLayout.test.js
@@ -154,17 +154,16 @@ describe('ChatLayout.vue', () => {
     expect(wrapper.vm.isConnected).toBe(true);
   });
 
-  test('responds to username-change event from ChatContent', async () => {
+  test('handleUsernameChange updates username and saves to localStorage', async () => {
     const wrapper = shallowMount(ChatLayout);
 
     // Initial username (with mocked Math.random)
     expect(wrapper.vm.username).toBe('User_500');
 
-    // Find ChatContent and trigger the event
-    const chatContent = wrapper.findComponent({ name: 'ChatContent' });
-    chatContent.vm.$emit('username-change', 'NewUsername');
+    // Call handleUsernameChange directly (username changes now come from Clerk, not ChatContent)
+    wrapper.vm.handleUsernameChange('NewUsername');
 
-    // Wait for Vue to process the event
+    // Wait for Vue to process
     await wrapper.vm.$nextTick();
 
     // Check if the username was updated

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -141,8 +141,6 @@ describe('Server Module - Comprehensive', () => {
           mockSocket.chatMessageCallback = callback;
         } else if (event === 'disconnect') {
           mockSocket.disconnectCallback = callback;
-        } else if (event === 'username_change') {
-          mockSocket.usernameChangeCallback = callback;
         } else if (event === 'join_channel') {
           mockSocket.joinChannelCallback = callback;
         }
@@ -263,47 +261,6 @@ describe('Server Module - Comprehensive', () => {
     }
     
     // No specific behavior to test here, just covering the code path
-  });
-  
-  test('handles username_change event and broadcasts notification', async () => {
-    // Verify socket.on was called for username_change event
-    expect(mockSocket.on).toHaveBeenCalledWith('username_change', expect.any(Function));
-
-    // Store the username_change callback for testing
-    const usernameChangeCallback = mockSocket.on.mock.calls.find(
-      call => call[0] === 'username_change'
-    )[1];
-
-    // Setup mock socket.to emitter
-    const mockToEmitter = jest.fn();
-    mockSocket.to.mockReturnValue({ emit: mockToEmitter });
-
-    // Prepare test data
-    const changeData = {
-      oldUsername: 'OldUserName',
-      newUsername: 'NewUserName'
-    };
-
-    // Call the handler (it's async now)
-    await usernameChangeCallback(changeData);
-
-    // Verify username was updated and broadcast to the room
-    expect(mockSocket.to).toHaveBeenCalledWith('general');
-    expect(mockToEmitter).toHaveBeenCalledWith('chat_message', expect.objectContaining({
-      username: 'System',
-      message: `${changeData.oldUsername} changed their username to ${changeData.newUsername}`
-    }));
-
-    // Verify database INSERT was called
-    expect(mockPool.query).toHaveBeenCalledWith(
-      expect.stringContaining('INSERT INTO messages'),
-      expect.arrayContaining([
-        expect.any(String), // timestamp
-        'System',
-        `${changeData.oldUsername} changed their username to ${changeData.newUsername}`,
-        'general' // default channel
-      ])
-    );
   });
   
   test('configures express with static file middleware', () => {
@@ -458,9 +415,6 @@ describe('Server Module - Comprehensive', () => {
 
     // Test chat_message with no channel specified
     await handlers.chat_message({ username: 'testuser', message: 'hello' });
-
-    // Test username_change with no channel specified
-    await handlers.username_change({ oldUsername: 'old', newUsername: 'new' });
   });
 
   // File-based tests removed - replaced with database storage
@@ -757,71 +711,6 @@ describe('Server Module - Comprehensive', () => {
   test('rejects chat_message with missing username', async () => {
     await mockSocket.chatMessageCallback({ message: 'Hello' });
     expect(mockSocket.emit).toHaveBeenCalledWith('error', { message: 'Username is required' });
-  });
-
-  test('rejects username_change with empty new username', async () => {
-    await mockSocket.usernameChangeCallback({ oldUsername: 'Old', newUsername: '' });
-    expect(mockSocket.emit).toHaveBeenCalledWith('error', { message: 'Username cannot be empty' });
-  });
-
-  test('rejects username_change with missing new username', async () => {
-    await mockSocket.usernameChangeCallback({ oldUsername: 'Old' });
-    expect(mockSocket.emit).toHaveBeenCalledWith('error', { message: 'Username cannot be empty' });
-  });
-
-  test('rejects username_change exceeding max length', async () => {
-    const longUsername = 'a'.repeat(31);
-    await mockSocket.usernameChangeCallback({ oldUsername: 'Old', newUsername: longUsername });
-    expect(mockSocket.emit).toHaveBeenCalledWith('error', {
-      message: 'Username exceeds maximum length of 30 characters'
-    });
-  });
-
-  test('handles database error when saving username change', async () => {
-    // Mock socket for testing
-    const socket = {
-      join: jest.fn(),
-      leave: jest.fn(),
-      emit: jest.fn(),
-      on: jest.fn(),
-      to: jest.fn().mockReturnThis()
-    };
-
-    const io = {
-      on: jest.fn(),
-      to: jest.fn().mockReturnThis(),
-      emit: jest.fn()
-    };
-
-    // Mock pool.query to throw error on INSERT
-    mockPool.query.mockImplementation((sql) => {
-      if (sql.includes('INSERT')) {
-        return Promise.reject(new Error('Database write error'));
-      }
-      return Promise.resolve({ rows: [] });
-    });
-
-    // Get the socket handler function
-    const setupSocketHandlers = require('../src/server/index').setupSocketHandlers;
-    const socketHandler = setupSocketHandlers(io);
-
-    // Register handlers
-    socketHandler(socket);
-
-    // Get username_change handler
-    const usernameChangeHandler = socket.on.mock.calls.find(call => call[0] === 'username_change')[1];
-
-    // Spy on console.error
-    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-
-    // Test username_change with database error
-    await usernameChangeHandler({ oldUsername: 'OldName', newUsername: 'NewName', channel: 'general' });
-
-    // Verify error was logged
-    expect(consoleErrorSpy).toHaveBeenCalledWith('Error saving username change to database:', expect.any(Error));
-
-    consoleErrorSpy.mockRestore();
-    mockPool.query.mockReset();
   });
 
 });


### PR DESCRIPTION
## Summary
This PR implements a sign-in requirement for posting messages in channels other than the welcome channel. Users who are not signed in can still view messages and post in the welcome channel, but are blocked from posting in other channels like general, growth, and feedback.

## Key Changes

### Frontend (ChatContent.vue)
- Added `isSignedIn` prop to track authentication status
- Introduced `canPost` computed property that returns `true` if user is signed in OR on the welcome channel
- Updated message input to be disabled when `canPost` is false with visual feedback (opacity and cursor)
- Modified `getInputPlaceholder()` to show "Sign in to post in this channel" when user cannot post
- Added early return in `sendMessage()` method to prevent sending when `canPost` is false
- Removed `/nick` command functionality for changing usernames (no longer supported)
- Removed socket listener for `username_change` events

### Backend (server/index.js)
- Removed `username_change` socket event handler entirely
- Removed username change validation and database logic
- Removed `MAX_USERNAME_LENGTH` constant

### Parent Component (ChatLayout.vue)
- Updated to pass `isSignedIn` prop to ChatContent component
- Removed `@username-change` event listener from ChatContent
- Kept `handleUsernameChange()` method for potential future use (username changes now come from Clerk authentication)

### Tests
- Updated ChatContent tests to reflect new sign-in behavior
- Added tests for `canPost` computed property in various scenarios
- Added tests for blocked message sending when not signed in
- Added tests for allowed posting on welcome channel without sign-in
- Updated input placeholder tests to expect sign-in prompt
- Removed tests for `/nick` command functionality
- Updated server tests to remove username_change event tests
- Updated ChatLayout tests to reflect removal of username-change event emission

## Implementation Details
- The welcome channel remains publicly accessible for posting without authentication
- All other channels require sign-in to post (but not to view)
- The UI provides clear feedback when posting is disabled
- Backend validation is simplified by removing the username change feature

https://claude.ai/code/session_014HuSktYQQmJhSJP28ZHYJR