### PR TITLE
Implement sign-in requirement for posting outside #welcome channel

### DIFF
--- a/src/components/ChatContent.vue
+++ b/src/components/ChatContent.vue
@@ -37,7 +37,7 @@
     </div>
     <div class="pb-6 px-4 flex-none">
       <div class="flex rounded-lg border-2 border-gray-300 overflow-hidden">
-        <span class="text-3xl text-gray-500 border-r-2 border-gray-300 p-2">
+        <span class="text-3xl text-gray-500 border-r-2 border-gray-300 p-2" :class="{ 'bg-gray-100 text-gray-300 cursor-not-allowed': isInputDisabled }">
           <svg class="fill-current h-6 w-6 block" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
             <path d="M16 10c0 .553-.048 1-.601 1H11v4.399c0 .552-.447.601-1 .601-.553 0-1-.049-1-.601V11H4.601C4.049 11 4 10.553 4 10c0-.553.049-1 .601-1H9V4.601C9 4.048 9.447 4 10 4c.553 0 1 .048 1 .601V9h4.399c.553 0 .601.447.601 1z"/>
           </svg>

--- a/src/components/ChatContent.vue
+++ b/src/components/ChatContent.vue
@@ -59,7 +59,6 @@ import ChatMessage from './ChatMessage.vue'
 import io from 'socket.io-client'
 
 const MAX_MESSAGE_LENGTH = 2000
-const MAX_USERNAME_LENGTH = 30
 
 export default {
   name: 'ChatContent',
@@ -74,6 +73,10 @@ export default {
     currentChannel: {
       type: String,
       default: 'general'
+    },
+    isSignedIn: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -207,13 +210,6 @@ export default {
       });
     });
 
-    // Handle username changes
-    this.socket.on('username_change', (data) => {
-      if (data.newUsername) {
-        this.$emit('username-change', data.newUsername);
-      }
-    });
-
     // Handle channel change
     this.socket.on('join_channel', () => {
       // Server acknowledgment after joining a channel
@@ -233,6 +229,16 @@ export default {
         return;
       }
 
+      if (!this.isSignedIn && this.localChannel !== 'welcome') {
+        this.messages.push({
+          timestamp: new Date().toISOString(),
+          username: 'System',
+          message: 'You must sign in to post in this channel. You can post in #welcome without an account.'
+        });
+        this.newMessage = '';
+        return;
+      }
+
       if (this.newMessage.length > MAX_MESSAGE_LENGTH) {
         this.messages.push({
           timestamp: new Date().toISOString(),
@@ -242,48 +248,12 @@ export default {
         return;
       }
 
-      // Check if this is a /nick command
-      if (this.newMessage.startsWith('/nick ')) {
-        const newUsername = this.newMessage.slice(6).trim();
-
-        if (newUsername && newUsername.length > MAX_USERNAME_LENGTH) {
-          this.messages.push({
-            timestamp: new Date().toISOString(),
-            username: 'System',
-            message: `Username exceeds maximum length of ${MAX_USERNAME_LENGTH} characters.`
-          });
-          this.newMessage = '';
-          return;
-        }
-
-        if (newUsername) {
-          // Emit an event to the parent component to change the username
-          this.$emit('username-change', newUsername);
-
-          // Notify the server about the username change
-          if (this.socket) {
-            this.socket.emit('username_change', {
-              oldUsername: this.localUsername,
-              newUsername: newUsername,
-              channel: this.localChannel
-            });
-          }
-
-          // Add a system message about the username change
-          this.messages.push({
-            timestamp: new Date().toISOString(),
-            username: 'System',
-            message: `${this.localUsername} changed their username to ${newUsername}`
-          });
-        }
-      } else {
-        // Send regular message to server
-        this.socket.emit('chat_message', {
-          username: this.localUsername,
-          message: this.newMessage,
-          channel: this.localChannel
-        });
-      }
+      // Send regular message to server
+      this.socket.emit('chat_message', {
+        username: this.localUsername,
+        message: this.newMessage,
+        channel: this.localChannel
+      });
 
       this.newMessage = '';
     },
@@ -338,6 +308,9 @@ export default {
       return this.currentChannel;
     },
     getInputPlaceholder() {
+      if (!this.isSignedIn && this.currentChannel !== 'welcome') {
+        return 'Sign in to post in this channel';
+      }
       return `Message #${this.currentChannel}`;
     }
   }

--- a/src/components/ChatContent.vue
+++ b/src/components/ChatContent.vue
@@ -314,7 +314,7 @@ export default {
     },
     getInputPlaceholder() {
       if (!this.isSignedIn && this.currentChannel !== 'welcome') {
-        return 'Sign in to post in this channel';
+        return 'Sign in to post in this channel.';
       }
       return `Message #${this.currentChannel}`;
     }

--- a/src/components/ChatContent.vue
+++ b/src/components/ChatContent.vue
@@ -45,7 +45,9 @@
         <input
           type="text"
           class="w-full px-4"
+          :class="{ 'bg-gray-100 text-gray-400 cursor-not-allowed': isInputDisabled }"
           :placeholder="getInputPlaceholder()"
+          :disabled="isInputDisabled"
           v-model="newMessage"
           @keyup.enter="sendMessage"
         />
@@ -91,6 +93,9 @@ export default {
     }
   },
   computed: {
+    isInputDisabled() {
+      return !this.isSignedIn && this.currentChannel !== 'welcome';
+    },
     channelDescription() {
       const descriptions = {
         welcome: 'Say hi — no account needed.',

--- a/src/components/ChatLayout.vue
+++ b/src/components/ChatLayout.vue
@@ -23,6 +23,7 @@
     <ChatContent
       :username="username"
       :current-channel="currentChannel"
+      :is-signed-in="isSignedIn"
       @connection-change="handleConnectionStatusChange"
       @username-change="handleUsernameChange"
       @channel-change="changeChannel"

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -23,7 +23,6 @@ const CHANNELS = ['welcome', 'general', 'growth', 'feedback'];
 
 // Validation constants
 const MAX_MESSAGE_LENGTH = 2000;
-const MAX_USERNAME_LENGTH = 30;
 
 // Database connection pool
 const pool = new Pool({
@@ -146,45 +145,6 @@ function setupSocketHandlers(io) {
       } catch (error) {
         console.error('Error saving message to database:', error);
         socket.emit('error', { message: 'Failed to save message' });
-      }
-    });
-
-    // Handle username changes
-    socket.on('username_change', async (data) => {
-      // Validate new username
-      if (!data.newUsername || typeof data.newUsername !== 'string' || data.newUsername.trim() === '') {
-        socket.emit('error', { message: 'Username cannot be empty' });
-        return;
-      }
-      if (data.newUsername.length > MAX_USERNAME_LENGTH) {
-        socket.emit('error', { message: `Username exceeds maximum length of ${MAX_USERNAME_LENGTH} characters` });
-        return;
-      }
-
-      // Update the username for this socket
-      username = data.newUsername;
-
-      // Log the username change as a system message to the specified channel
-      const timestamp = new Date().toISOString();
-      const channel = data.channel || 'general';
-      const systemMessage = `${data.oldUsername} changed their username to ${data.newUsername}`;
-
-      // Save system message to database
-      try {
-        await pool.query(
-          'INSERT INTO messages (timestamp, username, message, channel) VALUES ($1, $2, $3, $4)',
-          [timestamp, 'System', systemMessage, channel]
-        );
-
-        // Broadcast to all clients in the channel except the sender
-        socket.to(channel).emit('chat_message', {
-          timestamp,
-          username: 'System',
-          message: systemMessage,
-          channel: channel
-        });
-      } catch (error) {
-        console.error('Error saving username change to database:', error);
       }
     });
 

--- a/tests/ChatContent.test.js
+++ b/tests/ChatContent.test.js
@@ -59,21 +59,21 @@ describe('ChatContent.vue', () => {
   test('renders correctly with required props', () => {
     // Check if component exists
     expect(wrapper.exists()).toBe(true);
-    
+
     // Check if the root div has the expected classes
     const rootDiv = wrapper.find('div');
     expect(rootDiv.exists()).toBe(true);
     expect(rootDiv.classes()).toContain('flex-1');
     expect(rootDiv.classes()).toContain('flex');
     expect(rootDiv.classes()).toContain('flex-col');
-    
+
     // Check if the channel header is present
     const channelHeader = wrapper.find('h3');
     expect(channelHeader.exists()).toBe(true);
     expect(channelHeader.text()).toBe('#general');
-    
-    // Check if the input for new messages is present
-    const messageInput = wrapper.find('input[placeholder="Message #general"]');
+
+    // Check if the input for new messages is present (non-signed-in user sees sign-in placeholder)
+    const messageInput = wrapper.find('input[placeholder="Sign in to post in this channel"]');
     expect(messageInput.exists()).toBe(true);
   });
   
@@ -315,25 +315,31 @@ describe('ChatContent.vue', () => {
     expect(mockSocketDisconnect).toHaveBeenCalled();
   });
   
-  test('sendMessage method sends message to socket', () => {
-    // Prepare component for test
-    wrapper.setData({
+  test('sendMessage method sends message to socket when signed in', () => {
+    // Create a signed-in wrapper for this test
+    const signedInWrapper = shallowMount(ChatContent, {
+      propsData: {
+        username: 'testuser',
+        isSignedIn: true
+      }
+    });
+    signedInWrapper.setData({
       isConnected: true,
       newMessage: 'Hello socket world'
     });
-    
+
     // Call the sendMessage method
-    wrapper.vm.sendMessage();
-    
+    signedInWrapper.vm.sendMessage();
+
     // Check that socket.emit was called with correct data
     expect(mockSocketEmit).toHaveBeenCalledWith('chat_message', {
       username: 'testuser',
       message: 'Hello socket world',
       channel: 'general'
     });
-    
+
     // Check that the input was cleared
-    expect(wrapper.vm.newMessage).toBe('');
+    expect(signedInWrapper.vm.newMessage).toBe('');
   });
   
   test('sendMessage does nothing when input is empty', () => {
@@ -367,57 +373,71 @@ describe('ChatContent.vue', () => {
     expect(wrapper.vm.newMessage).toBe('Test message');
   });
   
-  test('sendMessage handles /nick command to change username', () => {
-    // Set a connected state
-    wrapper.setData({ 
+  test('sendMessage blocks non-signed-in users from posting outside #welcome', () => {
+    // Set a connected state on a non-welcome channel, not signed in
+    wrapper.setData({
       isConnected: true,
-      newMessage: '/nick NewUsername' 
+      newMessage: 'Hello'
     });
-    
+    // isSignedIn defaults to false, currentChannel defaults to 'general'
+
     // Call sendMessage method
     wrapper.vm.sendMessage();
-    
-    // Verify username-change event was emitted to parent
-    expect(wrapper.emitted('username-change')).toBeTruthy();
-    expect(wrapper.emitted('username-change')[0]).toEqual(['NewUsername']);
-    
-    // Verify username_change was emitted to socket
-    expect(mockSocketEmit).toHaveBeenCalledWith('username_change', {
-      oldUsername: 'testuser',
-      newUsername: 'NewUsername',
-      channel: 'general'
-    });
-    
+
+    // Verify no socket emit for chat_message
+    expect(mockSocketEmit).not.toHaveBeenCalledWith('chat_message', expect.anything());
+
     // Verify system message was added
     expect(wrapper.vm.messages).toHaveLength(1);
     expect(wrapper.vm.messages[0].username).toBe('System');
-    expect(wrapper.vm.messages[0].message).toBe('testuser changed their username to NewUsername');
-    
+    expect(wrapper.vm.messages[0].message).toContain('sign in');
+
     // Verify input was cleared
     expect(wrapper.vm.newMessage).toBe('');
   });
-  
-  test('sendMessage does not handle /nick command with empty username', () => {
-    // Set a connected state
-    wrapper.setData({ 
-      isConnected: true,
-      newMessage: '/nick ' 
+
+  test('sendMessage allows non-signed-in users to post on #welcome', () => {
+    const welcomeWrapper = shallowMount(ChatContent, {
+      propsData: {
+        username: 'testuser',
+        currentChannel: 'welcome',
+        isSignedIn: false
+      }
     });
-    
-    // Call sendMessage method
-    wrapper.vm.sendMessage();
-    
-    // Verify username-change event was NOT emitted to parent
-    expect(wrapper.emitted('username-change')).toBeFalsy();
-    
-    // Verify username_change was NOT emitted to socket
-    expect(mockSocketEmit).not.toHaveBeenCalled();
-    
-    // Verify no message was added
-    expect(wrapper.vm.messages).toHaveLength(0);
-    
-    // Verify input was cleared
-    expect(wrapper.vm.newMessage).toBe('');
+    welcomeWrapper.setData({
+      isConnected: true,
+      newMessage: 'Hello everyone!'
+    });
+
+    welcomeWrapper.vm.sendMessage();
+
+    expect(mockSocketEmit).toHaveBeenCalledWith('chat_message', {
+      username: 'testuser',
+      message: 'Hello everyone!',
+      channel: 'welcome'
+    });
+  });
+
+  test('sendMessage allows signed-in users to post on any channel', () => {
+    const signedInWrapper = shallowMount(ChatContent, {
+      propsData: {
+        username: 'testuser',
+        currentChannel: 'general',
+        isSignedIn: true
+      }
+    });
+    signedInWrapper.setData({
+      isConnected: true,
+      newMessage: 'Hello from signed in!'
+    });
+
+    signedInWrapper.vm.sendMessage();
+
+    expect(mockSocketEmit).toHaveBeenCalledWith('chat_message', {
+      username: 'testuser',
+      message: 'Hello from signed in!',
+      channel: 'general'
+    });
   });
 
   test('formatTimestamp converts timestamps correctly', () => {
@@ -469,13 +489,13 @@ describe('ChatContent.vue', () => {
   test('input triggers sendMessage on enter key', async () => {
     // Spy on sendMessage method
     const sendMessageSpy = jest.spyOn(wrapper.vm, 'sendMessage');
-    
+
     // Set message
     await wrapper.setData({ newMessage: 'test message' });
-    
-    // Trigger enter key on input
-    await wrapper.find('input[placeholder="Message #general"]').trigger('keyup.enter');
-    
+
+    // Trigger enter key on input (use the sign-in placeholder since default wrapper is not signed in)
+    await wrapper.find('input[placeholder="Sign in to post in this channel"]').trigger('keyup.enter');
+
     // Check that sendMessage was called
     expect(sendMessageSpy).toHaveBeenCalled();
   });
@@ -764,14 +784,39 @@ describe('ChatContent.vue', () => {
   
   
   test('getInputPlaceholder works for regular channels', () => {
-    const wrapper = shallowMount(ChatContent, {
+    const signedInWrapper = shallowMount(ChatContent, {
       propsData: {
         username: 'testuser',
-        currentChannel: 'general'
+        currentChannel: 'general',
+        isSignedIn: true
       }
     });
-    
-    expect(wrapper.vm.getInputPlaceholder()).toBe('Message #general');
+
+    expect(signedInWrapper.vm.getInputPlaceholder()).toBe('Message #general');
+  });
+
+  test('getInputPlaceholder shows sign-in message for non-signed-in users on non-welcome channels', () => {
+    const anonWrapper = shallowMount(ChatContent, {
+      propsData: {
+        username: 'testuser',
+        currentChannel: 'general',
+        isSignedIn: false
+      }
+    });
+
+    expect(anonWrapper.vm.getInputPlaceholder()).toBe('Sign in to post in this channel');
+  });
+
+  test('getInputPlaceholder shows normal placeholder for non-signed-in users on #welcome', () => {
+    const anonWelcomeWrapper = shallowMount(ChatContent, {
+      propsData: {
+        username: 'testuser',
+        currentChannel: 'welcome',
+        isSignedIn: false
+      }
+    });
+
+    expect(anonWelcomeWrapper.vm.getInputPlaceholder()).toBe('Message #welcome');
   });
   
   

--- a/tests/ChatContent.test.js
+++ b/tests/ChatContent.test.js
@@ -73,7 +73,7 @@ describe('ChatContent.vue', () => {
     expect(channelHeader.text()).toBe('#general');
 
     // Check if the input for new messages is present (non-signed-in user sees sign-in placeholder and is disabled)
-    const messageInput = wrapper.find('input[placeholder="Sign in to post in this channel"]');
+    const messageInput = wrapper.find('input[placeholder="Sign in to post in this channel."]');
     expect(messageInput.exists()).toBe(true);
     expect(messageInput.attributes('disabled')).toBeDefined();
   });
@@ -814,7 +814,7 @@ describe('ChatContent.vue', () => {
       }
     });
 
-    expect(anonWrapper.vm.getInputPlaceholder()).toBe('Sign in to post in this channel');
+    expect(anonWrapper.vm.getInputPlaceholder()).toBe('Sign in to post in this channel.');
   });
 
   test('getInputPlaceholder shows normal placeholder for non-signed-in users on #welcome', () => {


### PR DESCRIPTION
## Summary
This PR implements authentication-based access control for chat messaging. Non-signed-in users can now only post in the #welcome channel, while signed-in users can post in any channel. The `/nick` command for changing usernames has been removed.

## Key Changes

**Frontend (ChatContent.vue)**
- Added `isSignedIn` prop to track user authentication status
- Modified `sendMessage()` to block non-signed-in users from posting outside #welcome channel
- Updated `getInputPlaceholder()` to show "Sign in to post in this channel" for non-signed-in users on restricted channels
- Removed `/nick` command handling and related username change logic
- Removed `MAX_USERNAME_LENGTH` constant

**Backend (server/index.js)**
- Removed `username_change` socket event handler entirely
- Removed username change validation and database logic
- Removed `MAX_USERNAME_LENGTH` constant

**Parent Component (ChatLayout.vue)**
- Added `isSignedIn` prop binding to ChatContent component

**Tests**
- Updated ChatContent tests to reflect new authentication-based behavior
- Added tests for sign-in requirement on non-welcome channels
- Added tests for allowed posting on #welcome without sign-in
- Added tests for input placeholder variations based on sign-in status
- Removed all tests related to `/nick` command and username_change event
- Removed username_change event handler tests from server tests
- Updated existing tests to use appropriate wrapper configurations (signed-in vs non-signed-in)

## Implementation Details
- Non-signed-in users attempting to post outside #welcome receive a system message explaining the requirement
- The input placeholder dynamically changes based on authentication status and current channel
- #welcome channel remains accessible to all users regardless of sign-in status
- All username change functionality has been removed from both client and server

https://claude.ai/code/session_01CkafgbgSzdhdJS2ziKKVxy