### PR TITLE
Add polling mechanism for Clerk initialization with timeout

### DIFF
--- a/tests/ChatLayout.test.js
+++ b/tests/ChatLayout.test.js
@@ -287,12 +287,16 @@ describe('ChatLayout.vue', () => {
 
   // Clerk integration tests
   test('initClerk does nothing when window.Clerk is not available', async () => {
+    jest.useFakeTimers();
     delete window.Clerk;
     const wrapper = shallowMount(ChatLayout);
 
-    await wrapper.vm.initClerk();
+    const initPromise = wrapper.vm.initClerk();
+    jest.advanceTimersByTime(5000);
+    await initPromise;
 
     expect(wrapper.vm.isSignedIn).toBe(false);
+    jest.useRealTimers();
   });
 
   test('initClerk sets isSignedIn and username when Clerk user exists', async () => {
@@ -466,12 +470,16 @@ describe('ChatLayout.vue', () => {
   });
 
   test('handleSignIn does nothing when window.Clerk is not available', async () => {
+    jest.useFakeTimers();
     delete window.Clerk;
     const wrapper = shallowMount(ChatLayout);
 
-    await wrapper.vm.handleSignIn();
+    const signInPromise = wrapper.vm.handleSignIn();
+    jest.advanceTimersByTime(5000);
+    await signInPromise;
 
     expect(wrapper.vm.isSignedIn).toBe(false);
+    jest.useRealTimers();
   });
 
   test('handleSignIn opens Clerk sign-in and updates state when user signs in', async () => {


### PR DESCRIPTION
## Summary
This PR improves the reliability of Clerk authentication initialization by adding a polling mechanism that waits for the Clerk library to load before attempting to use it, rather than failing immediately if it's not available.

## Key Changes
- **Added `waitForClerk()` method**: Implements a polling mechanism with a configurable timeout (default 5000ms) that repeatedly checks for `window.Clerk` availability at 50ms intervals
- **Updated `initClerk()` method**: Now uses `waitForClerk()` to ensure Clerk is available before attempting to load and access user data
- **Updated `handleSignIn()` method**: Now uses `waitForClerk()` to ensure Clerk is available before opening the sign-in dialog
- **Refactored Clerk references**: Changed from direct `window.Clerk` references to using the resolved `clerk` variable for consistency and clarity
- **Updated tests**: Modified test cases to use fake timers and advance time appropriately when testing the polling behavior

## Implementation Details
- The polling mechanism resolves with the Clerk object if found, or `null` if the timeout is exceeded
- Both `initClerk()` and `handleSignIn()` gracefully handle the case where Clerk fails to load within the timeout period
- The 50ms polling interval provides a good balance between responsiveness and resource usage
- Tests now properly simulate the asynchronous polling behavior using Jest's fake timer utilities

https://claude.ai/code/session_012gXScM9yg3SYu3sugcuYnA