### PR TITLE
Fix UI flashing on refresh and reset username on logout

### DIFF
--- a/src/components/ChatLayout.vue
+++ b/src/components/ChatLayout.vue
@@ -151,6 +151,12 @@ export default {
           if (clerkName) {
             this.handleUsernameChange(clerkName);
           }
+          // Re-mount Clerk user button now that Clerk is loaded
+          // (needed when isSignedIn was cached — the early mount attempt
+          // from ServerSidebar's mounted() hook fails before Clerk loads)
+          if (this._clerkButtonEl) {
+            this.mountClerkUserButton(this._clerkButtonEl);
+          }
         } else if (this.isSignedIn) {
           // Cached state said signed in, but Clerk says not — reset
           this.isSignedIn = false;
@@ -211,6 +217,7 @@ export default {
       }
     },
     mountClerkUserButton(el) {
+      this._clerkButtonEl = el;
       try {
         if (!window.Clerk || !el) {
           return;

--- a/src/components/ServerSidebar.vue
+++ b/src/components/ServerSidebar.vue
@@ -71,6 +71,13 @@ export default {
       default: ''
     }
   },
+  mounted() {
+    if (this.isSignedIn) {
+      this.$nextTick(() => {
+        this.$emit('mount-user-button', this.$refs.clerkUserButton);
+      });
+    }
+  },
   watch: {
     isSignedIn(val) {
       if (val) {

--- a/tests/ChatLayout.test.js
+++ b/tests/ChatLayout.test.js
@@ -228,6 +228,44 @@ describe('ChatLayout.vue', () => {
     jest.useRealTimers();
   });
 
+  test('initClerk re-mounts Clerk user button when element was saved', async () => {
+    jest.useFakeTimers();
+    window.Clerk = {
+      load: jest.fn().mockResolvedValue(undefined),
+      mountUserButton: jest.fn(),
+      user: {
+        imageUrl: 'https://example.com/photo.jpg',
+        username: 'clerkuser',
+        firstName: 'Test',
+        emailAddresses: [{ emailAddress: 'test@example.com' }]
+      }
+    };
+
+    const wrapper = shallowMount(ChatLayout);
+    // Simulate ServerSidebar's mounted() having provided the element early
+    const el = document.createElement('div');
+    wrapper.vm._clerkButtonEl = el;
+
+    // Clear any prior calls from mounted() initClerk
+    window.Clerk.mountUserButton.mockClear();
+
+    await wrapper.vm.initClerk();
+
+    // initClerk should re-mount with the saved element
+    expect(window.Clerk.mountUserButton).toHaveBeenCalled();
+    expect(window.Clerk.mountUserButton.mock.calls[0][0]).toBe(el);
+    jest.useRealTimers();
+  });
+
+  test('mountClerkUserButton saves element reference', () => {
+    const wrapper = shallowMount(ChatLayout);
+    const el = document.createElement('div');
+
+    wrapper.vm.mountClerkUserButton(el);
+
+    expect(wrapper.vm._clerkButtonEl).toBe(el);
+  });
+
   test('initClerk resets cached state when Clerk says not signed in', async () => {
     jest.useFakeTimers();
     // Simulate cached signed-in state

--- a/tests/ServerSidebar.test.js
+++ b/tests/ServerSidebar.test.js
@@ -131,12 +131,36 @@ describe('ServerSidebar.vue', () => {
     expect(wrapper.find('[data-testid="join-button"]').exists()).toBe(true);
   });
 
-  test('does not emit mount-user-button when isSignedIn becomes false', async () => {
+  test('does not emit additional mount-user-button when isSignedIn becomes false', async () => {
     const wrapper = shallowMount(ServerSidebar, {
       propsData: { isSignedIn: true, username: 'testuser' }
     });
+    await wrapper.vm.$nextTick();
+
+    // mounted() emits once because isSignedIn starts true
+    const countAfterMount = (wrapper.emitted('mount-user-button') || []).length;
 
     await wrapper.setProps({ isSignedIn: false });
+    await wrapper.vm.$nextTick();
+
+    // No additional emission when going false
+    expect((wrapper.emitted('mount-user-button') || []).length).toBe(countAfterMount);
+  });
+
+  test('emits mount-user-button on mounted when isSignedIn is already true', async () => {
+    const wrapper = shallowMount(ServerSidebar, {
+      propsData: { isSignedIn: true, username: 'testuser' }
+    });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('mount-user-button')).toBeTruthy();
+    expect(wrapper.emitted('mount-user-button')).toHaveLength(1);
+  });
+
+  test('does not emit mount-user-button on mounted when isSignedIn is false', async () => {
+    const wrapper = shallowMount(ServerSidebar, {
+      propsData: { isSignedIn: false }
+    });
     await wrapper.vm.$nextTick();
 
     expect(wrapper.emitted('mount-user-button')).toBeFalsy();


### PR DESCRIPTION
Cache auth state (isSignedIn, profileImageUrl) in localStorage so the
UI renders the correct signed-in/signed-out state immediately on page
load instead of briefly flashing the wrong state while Clerk loads.
When Clerk confirms the session is gone, the cached state is cleared
and the username is reset to a guest name (User_XXX).

https://claude.ai/code/session_01Ppvha692Tquh2eFi3erzaJ