### PR TITLE
Fix messages not displaying by removing non-existent profile_image_url column from SQL queries

### DIFF
--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -245,8 +245,7 @@ describe('Server Module - Comprehensive', () => {
         expect.any(String), // timestamp
         messageData.username,
         messageData.message,
-        'general', // default channel
-        null // profileImageUrl
+        'general' // default channel
       ])
     );
 
@@ -495,8 +494,8 @@ describe('Server Module - Comprehensive', () => {
       if (sql.includes('SELECT') && sql.includes('messages')) {
         return Promise.resolve({
           rows: [
-            { timestamp: mockTimestamp, username: 'User1', message: 'Hello', profile_image_url: 'https://img.clerk.com/user1.jpg' },
-            { timestamp: mockTimestamp, username: 'User2', message: 'Hi there', profile_image_url: null }
+            { timestamp: mockTimestamp, username: 'User1', message: 'Hello' },
+            { timestamp: mockTimestamp, username: 'User2', message: 'Hi there' }
           ]
         });
       }
@@ -517,9 +516,9 @@ describe('Server Module - Comprehensive', () => {
     // Test user_connected with message history
     await userConnectedHandler({ username: 'TestUser', channel: 'general' });
 
-    // Verify formatted history was emitted (format: timestamp|username|profileImageUrl|message)
+    // Verify formatted history was emitted (format: timestamp|username||message)
     expect(socket.emit).toHaveBeenCalledWith('message_history', expect.arrayContaining([
-      expect.stringContaining('|User1|https://img.clerk.com/user1.jpg|Hello'),
+      expect.stringContaining('|User1||Hello'),
       expect.stringContaining('|User2||Hi there')
     ]));
 
@@ -530,7 +529,7 @@ describe('Server Module - Comprehensive', () => {
 
     // Verify formatted history was emitted
     expect(socket.emit).toHaveBeenCalledWith('message_history', expect.arrayContaining([
-      expect.stringContaining('|User1|https://img.clerk.com/user1.jpg|Hello'),
+      expect.stringContaining('|User1||Hello'),
       expect.stringContaining('|User2||Hi there')
     ]));
 


### PR DESCRIPTION
The database migration (002_add_profile_image_url.sql) was never applied to production,
so all SELECT and INSERT queries referencing profile_image_url failed, preventing any
messages from loading or being saved. Removed the column from queries while preserving
the pipe-delimited message format for client compatibility.

https://claude.ai/code/session_018hzMwKHotPATxkFPS3kvdD