### PR TITLE
Add profile image URL support to message history

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -63,12 +63,12 @@ app.get('*', (req, res) => {
 async function sendMessageHistory(socket, channel) {
   try {
     const result = await pool.query(
-      'SELECT timestamp, username, message FROM messages WHERE channel = $1 ORDER BY timestamp ASC',
+      'SELECT timestamp, username, message, profile_image_url FROM messages WHERE channel = $1 ORDER BY timestamp ASC',
       [channel]
     );
 
     const history = result.rows.map(row =>
-      `${row.timestamp.toISOString()}|${row.username}||${row.message}`
+      `${row.timestamp.toISOString()}|${row.username}|${row.profile_image_url || ''}|${row.message}`
     );
 
     socket.emit('message_history', history);
@@ -127,8 +127,8 @@ function setupSocketHandlers(io) {
       // Save message to database
       try {
         await pool.query(
-          'INSERT INTO messages (timestamp, username, message, channel) VALUES ($1, $2, $3, $4)',
-          [timestamp, data.username, data.message, channel]
+          'INSERT INTO messages (timestamp, username, message, channel, profile_image_url) VALUES ($1, $2, $3, $4, $5)',
+          [timestamp, data.username, data.message, channel, data.profileImageUrl || null]
         );
 
         // Create message object with channel explicitly included


### PR DESCRIPTION
## Summary
This PR adds support for storing and retrieving user profile image URLs in the messaging system. Profile images are now persisted to the database and included in message history.

## Key Changes
- Updated `sendMessageHistory()` to query and include `profile_image_url` field from the messages table
- Modified message history format to include profile image URL in the pipe-delimited string (between username and message content)
- Updated message insertion query to store `profile_image_url` when saving new messages to the database
- Profile image URL defaults to `null` if not provided in the message data

## Implementation Details
- The profile image URL is extracted from `data.profileImageUrl` when a message is received
- Empty or missing profile URLs are handled gracefully with fallback values (`''` in history output, `null` in database)
- Message history format changed from `timestamp|username||message` to `timestamp|username|profile_image_url|message`

https://claude.ai/code/session_01MvKU5Qwc5nMx4SsTRETaMM