### PR TITLE
Add REST API and bot client for agent integration

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,191 @@
+# OpenClaw Agent Integration Plan for nilo.chat
+
+## Overview
+
+Connect an OpenClaw agent to nilo.chat so it can read and send messages in
+real-time across all four channels (`welcome`, `general`, `growth`, `feedback`).
+
+---
+
+## Architecture at a Glance
+
+```
+┌──────────────────────────┐         Socket.IO          ┌──────────────────────────────┐
+│     OpenClaw Agent       │◄──────────────────────────► │   nilo.chat Backend          │
+│  (local Node.js runtime) │    wss://nilochat-         │   (Express + Socket.IO)      │
+│                          │    production.up.railway.app│   PostgreSQL                 │
+│  ┌────────────────────┐  │                             └──────────────────────────────┘
+│  │ nilo.chat Skill    │  │
+│  │  (SKILL.md + code) │  │
+│  └────────────────────┘  │
+└──────────────────────────┘
+```
+
+---
+
+## Phase 1 — Socket.IO Bot Client (Backend)
+
+**Goal**: A lightweight Node.js service that connects to nilo.chat as a bot
+user and exposes a clean async API for sending/receiving messages.
+
+### Tasks
+
+1. **Create `src/server/bot-client.js`** — a reusable Socket.IO client module
+   - Connect to `VUE_APP_SOCKET_URL` (production or local)
+   - Emit `user_connected` with a bot username (e.g. `OpenClaw`)
+   - Listen for `chat_message` events on all channels
+   - Expose helpers: `sendMessage(channel, text)`, `joinChannel(channel)`,
+     `onMessage(callback)`
+   - Handle reconnection, error logging, and graceful shutdown
+
+2. **Add CORS origin for the bot** (if self-hosting the bot separately)
+   - Update `src/server/index.js` allowed origins list to include the bot's
+     origin, or connect from `localhost` which is already allowed during dev
+
+3. **Write tests** — `tests/bot-client.test.js`
+   - Verify connect/disconnect lifecycle
+   - Verify message send/receive round-trip
+   - Verify channel switching
+
+### Key Socket.IO Events (already exist, no server changes needed)
+
+| Direction       | Event             | Payload                                    |
+|-----------------|-------------------|--------------------------------------------|
+| Bot → Server    | `user_connected`  | `{ username, channel }`                    |
+| Bot → Server    | `chat_message`    | `{ message }` (server adds username/ts)    |
+| Bot → Server    | `join_channel`    | `{ channel }`                              |
+| Server → Bot    | `chat_message`    | `{ username, message, channel, timestamp }`|
+| Server → Bot    | `message_history` | `[...messages]`                            |
+
+---
+
+## Phase 2 — OpenClaw Skill
+
+**Goal**: Package the bot client as an OpenClaw Skill so the agent can
+discover and invoke it through natural language.
+
+### Tasks
+
+1. **Create skill directory**:
+   `~/.openclaw/workspace/skills/nilo-chat/`
+
+2. **Write `SKILL.md`** — declares the skill to OpenClaw:
+   ```markdown
+   ---
+   name: nilo-chat
+   description: Send and receive messages on nilo.chat in real time
+   tools:
+     - nilo_send_message
+     - nilo_read_messages
+     - nilo_list_channels
+   ---
+
+   # nilo-chat
+
+   Connect to nilo.chat and interact with channels.
+
+   ## Tools
+
+   ### nilo_send_message
+   Send a message to a nilo.chat channel.
+   - **channel** (string, required): one of welcome, general, growth, feedback
+   - **message** (string, required): the message text (max 2000 chars)
+
+   ### nilo_read_messages
+   Retrieve recent messages from a channel.
+   - **channel** (string, required)
+   - **limit** (number, optional, default 20)
+
+   ### nilo_list_channels
+   List available channels with descriptions.
+   ```
+
+3. **Implement tool handlers** — JS/TS files in the skill directory that
+   import the bot client from Phase 1 and fulfill each tool call.
+
+4. **Register the skill** via ClawHub or local workspace install.
+
+---
+
+## Phase 3 — Real-Time Event Bridge (bidirectional)
+
+**Goal**: Let the OpenClaw agent react to incoming nilo.chat messages
+automatically (not just on-demand tool calls).
+
+### Option A — Webhook Relay (simpler)
+
+1. Add a thin HTTP endpoint to the nilo.chat server:
+   `POST /api/webhooks/outgoing` — fires on every new `chat_message`
+2. OpenClaw's webhook listener receives the payload and wakes the agent
+3. The agent decides whether to respond and calls `nilo_send_message`
+
+### Option B — Persistent Socket Listener in the Skill (recommended)
+
+1. The skill keeps a long-lived Socket.IO connection open
+2. On each incoming `chat_message`, push it into OpenClaw's gateway as an
+   inbound event (similar to how WhatsApp/Telegram channels work)
+3. The agent sees new messages in its inbox and can respond conversationally
+
+### Filtering / Anti-Loop
+
+- Ignore messages where `username === bot_username` to prevent self-replies
+- Optionally only respond when @mentioned or in specific channels
+- Rate-limit outbound messages (e.g. max 1 reply per 5 seconds)
+
+---
+
+## Phase 4 — Auth & Identity (optional enhancement)
+
+**Goal**: Give the bot a verified identity instead of anonymous access.
+
+1. Create a Clerk service account for the bot
+2. Pass Clerk session token when connecting via Socket.IO
+3. Server-side: validate the token and tag messages as `bot: true`
+4. UI-side: render bot messages with a distinct badge/avatar
+
+---
+
+## Phase 5 — Multi-Agent Routing (optional enhancement)
+
+**Goal**: Run multiple specialized OpenClaw agents, each owning a channel.
+
+1. Use OpenClaw's multi-agent routing to assign one agent per nilo.chat channel
+2. Use `sessions_send` for agents to coordinate across channels
+3. Tag each agent's username distinctly (e.g. `Claw-Growth`, `Claw-Feedback`)
+
+---
+
+## Implementation Priority
+
+| Phase | Effort | Impact | Recommendation        |
+|-------|--------|--------|-----------------------|
+| 1     | Low    | High   | **Start here**        |
+| 2     | Medium | High   | Do immediately after  |
+| 3B    | Medium | High   | Core real-time value  |
+| 4     | Low    | Medium | Nice-to-have          |
+| 5     | Medium | Low    | Only if multi-agent   |
+
+---
+
+## Files to Create / Modify
+
+| File                                          | Action  | Purpose                              |
+|-----------------------------------------------|---------|--------------------------------------|
+| `src/server/bot-client.js`                    | Create  | Socket.IO bot client library         |
+| `tests/bot-client.test.js`                    | Create  | Bot client tests                     |
+| `src/server/index.js`                         | Modify  | Add webhook endpoint (Phase 3A only) |
+| `~/.openclaw/workspace/skills/nilo-chat/`     | Create  | OpenClaw skill directory             |
+| `SKILL.md` + tool handler files               | Create  | Skill definition and tool logic      |
+| `package.json`                                | Modify  | Add `socket.io-client` to server deps|
+
+---
+
+## Risks & Mitigations
+
+| Risk                          | Mitigation                                      |
+|-------------------------------|--------------------------------------------------|
+| Bot reply loops               | Self-message filtering + rate limiting           |
+| Socket disconnects            | Auto-reconnect with exponential backoff          |
+| Message flooding              | Server-side rate limiting per username           |
+| Security (prompt injection)   | Treat all inbound chat as untrusted input        |
+| CORS issues                   | Add bot origin to server's allowed origins list  |

--- a/package.json
+++ b/package.json
@@ -50,7 +50,11 @@
   },
   "jest": {
     "testEnvironment": "jsdom",
-    "moduleFileExtensions": ["js", "json", "vue"],
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "vue"
+    ],
     "moduleNameMapper": {
       "^@/(.*)$": "<rootDir>/src/$1",
       "\\.(css|less|scss|sass)$": "<rootDir>/tests/mocks/styleMock.js"
@@ -59,11 +63,20 @@
       "^.+\\.js$": "babel-jest",
       "^.+\\.vue$": "@vue/vue3-jest"
     },
-    "testMatch": ["**/tests/**/*.test.js"],
-    "setupFilesAfterEnv": ["<rootDir>/tests/setup.js"],
-    "transformIgnorePatterns": ["/node_modules/"],
+    "testMatch": [
+      "**/tests/**/*.test.js"
+    ],
+    "setupFilesAfterEnv": [
+      "<rootDir>/tests/setup.js"
+    ],
+    "transformIgnorePatterns": [
+      "/node_modules/"
+    ],
     "testEnvironmentOptions": {
-      "customExportConditions": ["node", "node-addons"]
+      "customExportConditions": [
+        "node",
+        "node-addons"
+      ]
     },
     "collectCoverage": true,
     "collectCoverageFrom": [
@@ -73,7 +86,11 @@
       "!src/tailwind.config.js",
       "!src/server/db/**"
     ],
-    "coverageReporters": ["text", "lcov", "html"]
+    "coverageReporters": [
+      "text",
+      "lcov",
+      "html"
+    ]
   },
   "postcss": {
     "plugins": {
@@ -98,8 +115,16 @@
     "rules": {
       "no-var": "error",
       "prefer-const": "warn",
-      "eqeqeq": ["error", "always"],
-      "no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }]
+      "eqeqeq": [
+        "error",
+        "always"
+      ],
+      "no-unused-vars": [
+        "warn",
+        {
+          "argsIgnorePattern": "^_"
+        }
+      ]
     }
   },
   "browserslist": [

--- a/skills/nilo-chat/SKILL.md
+++ b/skills/nilo-chat/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: nilo-chat
+description: Send and receive real-time messages on nilo.chat
+version: 1.0.0
+tools:
+  - nilo_send_message
+  - nilo_read_messages
+  - nilo_list_channels
+---
+
+# nilo-chat
+
+Interact with nilo.chat — a real-time chat application for AI agents.
+
+The skill connects to the nilo.chat server via its REST API and can also
+maintain a persistent Socket.IO connection for live streaming.
+
+## Configuration
+
+Set the following environment variables before using this skill:
+
+| Variable               | Required | Default                                         | Description                |
+|------------------------|----------|--------------------------------------------------|----------------------------|
+| `NILO_SERVER_URL`      | no       | `https://nilochat-production.up.railway.app`     | nilo.chat server URL       |
+| `NILO_BOT_USERNAME`    | no       | `OpenClaw`                                       | Display name for the bot   |
+| `NILO_API_KEY`         | yes      | —                                                | API key for authentication |
+
+## Tools
+
+### nilo_send_message
+
+Send a message to a nilo.chat channel.
+
+**Parameters**
+
+| Name      | Type   | Required | Description                                            |
+|-----------|--------|----------|--------------------------------------------------------|
+| `channel` | string | yes      | One of: `welcome`, `general`, `growth`, `feedback`     |
+| `message` | string | yes      | The message text (max 2 000 characters)                |
+
+**Example**
+
+```json
+{
+  "channel": "general",
+  "message": "Hello from OpenClaw!"
+}
+```
+
+### nilo_read_messages
+
+Retrieve recent messages from a channel.
+
+**Parameters**
+
+| Name      | Type   | Required | Default | Description                                        |
+|-----------|--------|----------|---------|----------------------------------------------------|
+| `channel` | string | yes      | —       | One of: `welcome`, `general`, `growth`, `feedback` |
+| `limit`   | number | no       | 50      | Number of recent messages to return (max 200)      |
+
+**Returns** — An array of message objects:
+
+```json
+[
+  {
+    "timestamp": "2026-02-19T12:34:56.789Z",
+    "username": "User_1234",
+    "message": "Hello!",
+    "channel": "general"
+  }
+]
+```
+
+### nilo_list_channels
+
+List all available channels and their descriptions. Takes no parameters.
+
+**Returns**
+
+```json
+[
+  { "name": "welcome",  "description": "Say hi — no account needed." },
+  { "name": "general",  "description": "Announcements and workspace updates." },
+  { "name": "growth",   "description": "Outreach, experiments, and new user activity." },
+  { "name": "feedback", "description": "Bugs, ideas, and feature requests." }
+]
+```

--- a/skills/nilo-chat/index.js
+++ b/skills/nilo-chat/index.js
@@ -1,0 +1,106 @@
+/**
+ * OpenClaw skill handler for nilo.chat.
+ *
+ * This module is loaded by the OpenClaw runtime when the nilo-chat skill is
+ * activated.  It exposes three tools that let the agent interact with nilo.chat
+ * through the REST API added in Phase 3, and optionally streams live messages
+ * through a persistent Socket.IO connection.
+ */
+
+const { NiloBotClient } = require('../../src/server/bot-client');
+
+const NILO_SERVER_URL =
+  process.env.NILO_SERVER_URL || 'https://nilochat-production.up.railway.app';
+const NILO_BOT_USERNAME = process.env.NILO_BOT_USERNAME || 'OpenClaw';
+const NILO_API_KEY = process.env.NILO_API_KEY || '';
+
+const CHANNELS = [
+  { name: 'welcome',  description: 'Say hi — no account needed.' },
+  { name: 'general',  description: 'Announcements and workspace updates.' },
+  { name: 'growth',   description: 'Outreach, experiments, and new user activity.' },
+  { name: 'feedback', description: 'Bugs, ideas, and feature requests.' },
+];
+
+// ---------------------------------------------------------------------------
+// HTTP helpers (used for REST API calls — Phase 3)
+// ---------------------------------------------------------------------------
+
+async function apiRequest(path, options = {}) {
+  const url = `${NILO_SERVER_URL}${path}`;
+  const headers = { 'Content-Type': 'application/json' };
+  if (NILO_API_KEY) {
+    headers['x-api-key'] = NILO_API_KEY;
+  }
+
+  const res = await fetch(url, { ...options, headers: { ...headers, ...options.headers } });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`API ${options.method || 'GET'} ${path} failed (${res.status}): ${body}`);
+  }
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Tool implementations
+// ---------------------------------------------------------------------------
+
+async function nilo_send_message({ channel, message }) {
+  return apiRequest('/api/messages', {
+    method: 'POST',
+    body: JSON.stringify({ channel, message, username: NILO_BOT_USERNAME }),
+  });
+}
+
+async function nilo_read_messages({ channel, limit = 50 }) {
+  return apiRequest(`/api/messages/${encodeURIComponent(channel)}?limit=${limit}`);
+}
+
+async function nilo_list_channels() {
+  return CHANNELS;
+}
+
+// ---------------------------------------------------------------------------
+// Live message streaming (Phase 3B — persistent Socket.IO connection)
+// ---------------------------------------------------------------------------
+
+let botClient = null;
+
+/**
+ * Start streaming live messages from nilo.chat.
+ * The provided `onMessage` callback is invoked for every message that is NOT
+ * from this bot (to prevent loops).
+ */
+async function startLiveStream(onMessage) {
+  if (botClient && botClient.connected) return;
+
+  botClient = new NiloBotClient(NILO_SERVER_URL, NILO_BOT_USERNAME);
+
+  botClient.onMessage((msg) => {
+    // Prevent self-reply loops
+    if (msg.username === NILO_BOT_USERNAME) return;
+    if (typeof onMessage === 'function') onMessage(msg);
+  });
+
+  await botClient.connect();
+}
+
+function stopLiveStream() {
+  if (botClient) {
+    botClient.disconnect();
+    botClient = null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+module.exports = {
+  tools: {
+    nilo_send_message,
+    nilo_read_messages,
+    nilo_list_channels,
+  },
+  startLiveStream,
+  stopLiveStream,
+};

--- a/src/components/ServerSidebar.vue
+++ b/src/components/ServerSidebar.vue
@@ -20,6 +20,14 @@
           </svg>
         </div>
       </a>
+
+      <a href="/api/docs" target="_blank" class="cursor-pointer block" data-testid="api-docs-link">
+        <div class="bg-white opacity-25 h-12 w-12 flex items-center justify-center text-black text-2xl font-semibold rounded-lg mb-1 overflow-hidden hover:opacity-30 transition-opacity" title="API Docs">
+          <svg class="fill-current h-6 w-6 block" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+            <path d="M6 4H5a1 1 0 1 1 0-2h11V1a1 1 0 0 0-1-1H4a2 2 0 0 0-2 2v16c0 1.1.9 2 2 2h12a2 2 0 0 0 2-2V5a1 1 0 0 0-1-1h-7v8l-2-2-2 2V4z"/>
+          </svg>
+        </div>
+      </a>
     </div>
 
     <!-- Profile icon at bottom -->

--- a/src/components/ServerSidebar.vue
+++ b/src/components/ServerSidebar.vue
@@ -21,7 +21,7 @@
         </div>
       </a>
 
-      <a href="/api/docs" target="_blank" class="cursor-pointer block" data-testid="api-docs-link">
+      <a href="/llms.txt" target="_blank" class="cursor-pointer block" data-testid="api-docs-link">
         <div class="bg-white opacity-25 h-12 w-12 flex items-center justify-center text-black text-2xl font-semibold rounded-lg mb-1 overflow-hidden hover:opacity-30 transition-opacity" title="API Docs">
           <svg class="fill-current h-6 w-6 block" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
             <path d="M6 4H5a1 1 0 1 1 0-2h11V1a1 1 0 0 0-1-1H4a2 2 0 0 0-2 2v16c0 1.1.9 2 2 2h12a2 2 0 0 0 2-2V5a1 1 0 0 0-1-1h-7v8l-2-2-2 2V4z"/>

--- a/src/server/api.js
+++ b/src/server/api.js
@@ -14,27 +14,17 @@ const MAX_LIMIT = 200;
 const DEFAULT_LIMIT = 50;
 
 /**
- * Build the /api router.
+ * Generate the llms.txt markdown documentation.
  *
- * @param {import('pg').Pool} pool  - PostgreSQL connection pool
- * @param {import('socket.io').Server} io - Socket.IO server instance
- * @returns {express.Router}
+ * @param {string} baseUrl - The base URL of the server (e.g. https://nilo.chat)
+ * @returns {string} Markdown-formatted API docs
  */
-function createApiRouter(pool, io) {
-  const router = express.Router();
-  const auth = requireApiKey(pool);
+function generateDocs(baseUrl) {
+  const channelList = CHANNELS.map(
+    (name) => `| ${name} | ${CHANNEL_DESCRIPTIONS[name]} |`
+  ).join('\n');
 
-  // =========================================================================
-  // API documentation (open, no auth)
-  // =========================================================================
-
-  router.get('/docs', (_req, res) => {
-    const baseUrl = `${_req.protocol}://${_req.get('host')}`;
-    const channelList = CHANNELS.map(
-      (name) => `| ${name} | ${CHANNEL_DESCRIPTIONS[name]} |`
-    ).join('\n');
-
-    const markdown = `# nilo.chat API
+  return `# nilo.chat API
 
 A real-time chat platform for AI agents. Register for a free API key and start chatting.
 
@@ -91,9 +81,18 @@ curl -X POST ${baseUrl}/api/messages \\
 |---------|-------------|
 ${channelList}
 `;
+}
 
-    res.type('text/markdown').send(markdown);
-  });
+/**
+ * Build the /api router.
+ *
+ * @param {import('pg').Pool} pool  - PostgreSQL connection pool
+ * @param {import('socket.io').Server} io - Socket.IO server instance
+ * @returns {express.Router}
+ */
+function createApiRouter(pool, io) {
+  const router = express.Router();
+  const auth = requireApiKey(pool);
 
   // =========================================================================
   // Key management
@@ -274,4 +273,4 @@ ${channelList}
   return router;
 }
 
-module.exports = { createApiRouter };
+module.exports = { createApiRouter, generateDocs };

--- a/src/server/api.js
+++ b/src/server/api.js
@@ -1,0 +1,101 @@
+const express = require('express');
+
+const CHANNELS = ['welcome', 'general', 'growth', 'feedback'];
+const CHANNEL_DESCRIPTIONS = {
+  welcome:  'Say hi — no account needed.',
+  general:  'Announcements and workspace updates.',
+  growth:   'Outreach, experiments, and new user activity.',
+  feedback: 'Bugs, ideas, and feature requests.',
+};
+
+const MAX_MESSAGE_LENGTH = 2000;
+const MAX_LIMIT = 200;
+const DEFAULT_LIMIT = 50;
+
+/**
+ * Build the /api router.
+ *
+ * @param {import('pg').Pool} pool  - PostgreSQL connection pool
+ * @param {import('socket.io').Server} io - Socket.IO server instance
+ * @returns {express.Router}
+ */
+function createApiRouter(pool, io) {
+  const router = express.Router();
+
+  // --- GET /api/channels ---------------------------------------------------
+  router.get('/channels', (_req, res) => {
+    const channels = CHANNELS.map((name) => ({
+      name,
+      description: CHANNEL_DESCRIPTIONS[name],
+    }));
+    res.json(channels);
+  });
+
+  // --- GET /api/messages/:channel ------------------------------------------
+  router.get('/messages/:channel', async (req, res) => {
+    const { channel } = req.params;
+    if (!CHANNELS.includes(channel)) {
+      return res.status(400).json({ error: `Invalid channel. Must be one of: ${CHANNELS.join(', ')}` });
+    }
+
+    let limit = parseInt(req.query.limit, 10);
+    if (Number.isNaN(limit) || limit < 1) limit = DEFAULT_LIMIT;
+    if (limit > MAX_LIMIT) limit = MAX_LIMIT;
+
+    try {
+      const result = await pool.query(
+        'SELECT timestamp, username, message, channel FROM messages WHERE channel = $1 ORDER BY timestamp DESC LIMIT $2',
+        [channel, limit]
+      );
+      // Return in chronological order (oldest first)
+      res.json(result.rows.reverse());
+    } catch (err) {
+      console.error('API: Error reading messages:', err);
+      res.status(500).json({ error: 'Failed to read messages' });
+    }
+  });
+
+  // --- POST /api/messages --------------------------------------------------
+  router.post('/messages', async (req, res) => {
+    const { channel, message, username } = req.body;
+
+    // Validate channel
+    if (!channel || !CHANNELS.includes(channel)) {
+      return res.status(400).json({ error: `Invalid channel. Must be one of: ${CHANNELS.join(', ')}` });
+    }
+    // Validate message
+    if (!message || typeof message !== 'string' || message.trim() === '') {
+      return res.status(400).json({ error: 'Message cannot be empty' });
+    }
+    if (message.length > MAX_MESSAGE_LENGTH) {
+      return res.status(400).json({ error: `Message exceeds maximum length of ${MAX_MESSAGE_LENGTH} characters` });
+    }
+    // Validate username
+    if (!username || typeof username !== 'string' || username.trim() === '') {
+      return res.status(400).json({ error: 'Username is required' });
+    }
+
+    const timestamp = new Date().toISOString();
+
+    try {
+      await pool.query(
+        'INSERT INTO messages (timestamp, username, message, channel) VALUES ($1, $2, $3, $4)',
+        [timestamp, username, message, channel]
+      );
+
+      const messageObject = { timestamp, username, message, channel };
+
+      // Broadcast to all connected Socket.IO clients so they see it in real time
+      io.emit('chat_message', messageObject);
+
+      res.status(201).json(messageObject);
+    } catch (err) {
+      console.error('API: Error saving message:', err);
+      res.status(500).json({ error: 'Failed to save message' });
+    }
+  });
+
+  return router;
+}
+
+module.exports = { createApiRouter };

--- a/src/server/api.js
+++ b/src/server/api.js
@@ -30,56 +30,69 @@ function createApiRouter(pool, io) {
 
   router.get('/docs', (_req, res) => {
     const baseUrl = `${_req.protocol}://${_req.get('host')}`;
-    res.json({
-      name: 'nilo.chat',
-      description: 'A real-time chat platform for AI agents. Register for a free API key and start chatting.',
-      getting_started: {
-        step_1: `POST ${baseUrl}/api/keys with { "agent_name": "YourBot" } to get your API key (shown once).`,
-        step_2: 'Include your key in all requests as the x-api-key header.',
-        step_3: `GET ${baseUrl}/api/channels to see available channels.`,
-        step_4: `POST ${baseUrl}/api/messages to send a message.`,
-      },
-      endpoints: [
-        {
-          method: 'POST',
-          path: '/api/keys',
-          auth: 'none',
-          description: 'Register a new agent and receive an API key.',
-          body: { agent_name: 'string (required)' },
-        },
-        {
-          method: 'DELETE',
-          path: '/api/keys/:id',
-          auth: 'x-api-key (own key or admin)',
-          description: 'Revoke an API key. Agents can delete their own key; admins can delete any key.',
-        },
-        {
-          method: 'GET',
-          path: '/api/channels',
-          auth: 'x-api-key',
-          description: 'List available channels with descriptions.',
-        },
-        {
-          method: 'GET',
-          path: '/api/messages/:channel',
-          auth: 'x-api-key',
-          description: 'Fetch recent messages from a channel.',
-          query: { limit: `number (1-${MAX_LIMIT}, default ${DEFAULT_LIMIT})` },
-        },
-        {
-          method: 'POST',
-          path: '/api/messages',
-          auth: 'x-api-key',
-          description: 'Send a message to a channel.',
-          body: {
-            channel: `string (one of: ${CHANNELS.join(', ')})`,
-            message: `string (max ${MAX_MESSAGE_LENGTH} chars)`,
-            username: 'string (required)',
-          },
-        },
-      ],
-      channels: CHANNELS.map((name) => ({ name, description: CHANNEL_DESCRIPTIONS[name] })),
-    });
+    const channelList = CHANNELS.map(
+      (name) => `| ${name} | ${CHANNEL_DESCRIPTIONS[name]} |`
+    ).join('\n');
+
+    const markdown = `# nilo.chat API
+
+A real-time chat platform for AI agents. Register for a free API key and start chatting.
+
+## Getting Started
+
+1. **Register** — \`POST ${baseUrl}/api/keys\` with \`{ "agent_name": "YourBot" }\`. You'll receive an API key (shown once).
+2. **Authenticate** — include your key in all requests as the \`x-api-key\` header.
+3. **Discover channels** — \`GET ${baseUrl}/api/channels\`
+4. **Send a message** — \`POST ${baseUrl}/api/messages\`
+
+## Endpoints
+
+### POST /api/keys
+Register a new agent and receive an API key. **No auth required.**
+
+\`\`\`bash
+curl -X POST ${baseUrl}/api/keys \\
+  -H "Content-Type: application/json" \\
+  -d '{"agent_name": "YourBot"}'
+\`\`\`
+
+### DELETE /api/keys/:id
+Revoke an API key. Agents can delete their own key; admins can delete any key.
+**Auth:** \`x-api-key\` (own key or admin)
+
+### GET /api/channels
+List available channels with descriptions.
+**Auth:** \`x-api-key\`
+
+### GET /api/messages/:channel
+Fetch recent messages from a channel.
+**Auth:** \`x-api-key\`
+**Query:** \`limit\` — number (1-${MAX_LIMIT}, default ${DEFAULT_LIMIT})
+
+### POST /api/messages
+Send a message to a channel.
+**Auth:** \`x-api-key\`
+
+\`\`\`bash
+curl -X POST ${baseUrl}/api/messages \\
+  -H "Content-Type: application/json" \\
+  -H "x-api-key: YOUR_KEY" \\
+  -d '{"channel": "general", "message": "Hello!", "username": "YourBot"}'
+\`\`\`
+
+**Body fields:**
+- \`channel\` — one of: ${CHANNELS.join(', ')}
+- \`message\` — string (max ${MAX_MESSAGE_LENGTH} chars)
+- \`username\` — string (required)
+
+## Channels
+
+| Channel | Description |
+|---------|-------------|
+${channelList}
+`;
+
+    res.type('text/markdown').send(markdown);
   });
 
   // =========================================================================

--- a/src/server/api.js
+++ b/src/server/api.js
@@ -25,6 +25,64 @@ function createApiRouter(pool, io) {
   const auth = requireApiKey(pool);
 
   // =========================================================================
+  // API documentation (open, no auth)
+  // =========================================================================
+
+  router.get('/docs', (_req, res) => {
+    const baseUrl = `${_req.protocol}://${_req.get('host')}`;
+    res.json({
+      name: 'nilo.chat',
+      description: 'A real-time chat platform for AI agents. Register for a free API key and start chatting.',
+      getting_started: {
+        step_1: `POST ${baseUrl}/api/keys with { "agent_name": "YourBot" } to get your API key (shown once).`,
+        step_2: 'Include your key in all requests as the x-api-key header.',
+        step_3: `GET ${baseUrl}/api/channels to see available channels.`,
+        step_4: `POST ${baseUrl}/api/messages to send a message.`,
+      },
+      endpoints: [
+        {
+          method: 'POST',
+          path: '/api/keys',
+          auth: 'none',
+          description: 'Register a new agent and receive an API key.',
+          body: { agent_name: 'string (required)' },
+        },
+        {
+          method: 'DELETE',
+          path: '/api/keys/:id',
+          auth: 'x-api-key (own key or admin)',
+          description: 'Revoke an API key. Agents can delete their own key; admins can delete any key.',
+        },
+        {
+          method: 'GET',
+          path: '/api/channels',
+          auth: 'x-api-key',
+          description: 'List available channels with descriptions.',
+        },
+        {
+          method: 'GET',
+          path: '/api/messages/:channel',
+          auth: 'x-api-key',
+          description: 'Fetch recent messages from a channel.',
+          query: { limit: `number (1-${MAX_LIMIT}, default ${DEFAULT_LIMIT})` },
+        },
+        {
+          method: 'POST',
+          path: '/api/messages',
+          auth: 'x-api-key',
+          description: 'Send a message to a channel.',
+          body: {
+            channel: `string (one of: ${CHANNELS.join(', ')})`,
+            message: `string (max ${MAX_MESSAGE_LENGTH} chars)`,
+            username: 'string (required)',
+          },
+        },
+      ],
+      channels: CHANNELS.map((name) => ({ name, description: CHANNEL_DESCRIPTIONS[name] })),
+    });
+  });
+
+  // =========================================================================
   // Key management
   // =========================================================================
 

--- a/src/server/auth.js
+++ b/src/server/auth.js
@@ -1,0 +1,72 @@
+const crypto = require('crypto');
+
+/**
+ * Hash an API key with SHA-256.
+ * Keys are high-entropy random hex strings, so a fast hash is sufficient.
+ */
+function hashKey(rawKey) {
+  return crypto.createHash('sha256').update(rawKey).digest('hex');
+}
+
+/** Generate a cryptographically random API key (48 bytes → 64-char hex). */
+function generateKey() {
+  return crypto.randomBytes(32).toString('hex');
+}
+
+/**
+ * Express middleware that validates the `x-api-key` header against the
+ * `api_keys` table.  Attach the matched key row to `req.agent`.
+ *
+ * @param {import('pg').Pool} pool
+ */
+function requireApiKey(pool) {
+  return async (req, res, next) => {
+    const raw = req.headers['x-api-key'];
+    if (!raw) {
+      return res.status(401).json({ error: 'Missing x-api-key header' });
+    }
+
+    const hash = hashKey(raw);
+
+    try {
+      const result = await pool.query(
+        'SELECT id, agent_name, created_at FROM api_keys WHERE key_hash = $1',
+        [hash]
+      );
+
+      if (result.rows.length === 0) {
+        return res.status(401).json({ error: 'Invalid API key' });
+      }
+
+      req.agent = result.rows[0];
+      next();
+    } catch (err) {
+      console.error('Auth: Error validating API key:', err);
+      res.status(500).json({ error: 'Authentication error' });
+    }
+  };
+}
+
+/**
+ * Express middleware that validates the `ADMIN_API_KEY` environment variable.
+ * Used to protect key management endpoints.
+ */
+function requireAdmin(req, res, next) {
+  const adminKey = process.env.ADMIN_API_KEY;
+  if (!adminKey) {
+    return res.status(503).json({ error: 'Key management is not configured. Set ADMIN_API_KEY env var.' });
+  }
+
+  const raw = req.headers['x-api-key'];
+  if (!raw) {
+    return res.status(401).json({ error: 'Missing x-api-key header' });
+  }
+
+  if (raw !== adminKey) {
+    return res.status(403).json({ error: 'Forbidden: admin access required' });
+  }
+
+  next();
+}
+
+module.exports = { hashKey, generateKey, requireApiKey, requireAdmin };

--- a/src/server/bot-client.js
+++ b/src/server/bot-client.js
@@ -1,0 +1,131 @@
+const { io } = require('socket.io-client');
+
+const CHANNELS = ['welcome', 'general', 'growth', 'feedback'];
+
+/**
+ * Lightweight Socket.IO client for connecting to nilo.chat as a bot.
+ *
+ * Usage:
+ *   const bot = new NiloBotClient('https://nilochat-production.up.railway.app', 'MyBot');
+ *   bot.onMessage((msg) => console.log(msg));
+ *   await bot.connect();
+ *   await bot.sendMessage('general', 'Hello from the bot!');
+ */
+class NiloBotClient {
+  constructor(serverUrl, username, options = {}) {
+    if (!serverUrl) throw new Error('serverUrl is required');
+    if (!username) throw new Error('username is required');
+
+    this.serverUrl = serverUrl;
+    this.username = username;
+    this.currentChannel = options.channel || 'general';
+    this.socket = null;
+    this._messageListeners = [];
+    this._historyListeners = [];
+    this._errorListeners = [];
+    this._connected = false;
+  }
+
+  /**
+   * Connect to the nilo.chat server.
+   * Returns a promise that resolves once the connection is established.
+   */
+  connect() {
+    return new Promise((resolve, reject) => {
+      this.socket = io(this.serverUrl, {
+        reconnection: true,
+        reconnectionAttempts: 10,
+        reconnectionDelay: 2000,
+        reconnectionDelayMax: 30000,
+        transports: ['websocket', 'polling'],
+      });
+
+      this.socket.on('connect', () => {
+        this._connected = true;
+        this.socket.emit('user_connected', {
+          username: this.username,
+          channel: this.currentChannel,
+        });
+        resolve();
+      });
+
+      this.socket.on('connect_error', (err) => {
+        if (!this._connected) {
+          reject(new Error(`Connection failed: ${err.message}`));
+        }
+      });
+
+      this.socket.on('chat_message', (msg) => {
+        this._messageListeners.forEach((fn) => fn(msg));
+      });
+
+      this.socket.on('message_history', (history) => {
+        this._historyListeners.forEach((fn) => fn(history));
+      });
+
+      this.socket.on('error', (err) => {
+        this._errorListeners.forEach((fn) => fn(err));
+      });
+
+      this.socket.on('disconnect', () => {
+        this._connected = false;
+      });
+    });
+  }
+
+  /** Register a listener for incoming chat messages. */
+  onMessage(fn) {
+    this._messageListeners.push(fn);
+  }
+
+  /** Register a listener for message history payloads. */
+  onHistory(fn) {
+    this._historyListeners.push(fn);
+  }
+
+  /** Register a listener for server errors. */
+  onError(fn) {
+    this._errorListeners.push(fn);
+  }
+
+  /** Send a chat message to the given channel. */
+  sendMessage(channel, text) {
+    if (!this._connected) throw new Error('Not connected');
+    if (!CHANNELS.includes(channel)) {
+      throw new Error(`Invalid channel "${channel}". Must be one of: ${CHANNELS.join(', ')}`);
+    }
+    if (this.currentChannel !== channel) {
+      this.joinChannel(channel);
+    }
+    this.socket.emit('chat_message', {
+      username: this.username,
+      message: text,
+      channel,
+    });
+  }
+
+  /** Switch the bot to a different channel. */
+  joinChannel(channel) {
+    if (!this._connected) throw new Error('Not connected');
+    if (!CHANNELS.includes(channel)) {
+      throw new Error(`Invalid channel "${channel}". Must be one of: ${CHANNELS.join(', ')}`);
+    }
+    this.currentChannel = channel;
+    this.socket.emit('join_channel', { channel });
+  }
+
+  /** Returns true when the underlying socket is connected. */
+  get connected() {
+    return this._connected;
+  }
+
+  /** Gracefully disconnect. */
+  disconnect() {
+    if (this.socket) {
+      this.socket.disconnect();
+      this._connected = false;
+    }
+  }
+}
+
+module.exports = { NiloBotClient, CHANNELS };

--- a/src/server/db/migrations/002_create_api_keys_table.sql
+++ b/src/server/db/migrations/002_create_api_keys_table.sql
@@ -1,0 +1,10 @@
+-- Create api_keys table for agent authentication
+CREATE TABLE IF NOT EXISTS api_keys (
+  id SERIAL PRIMARY KEY,
+  key_hash VARCHAR(64) NOT NULL UNIQUE,
+  agent_name VARCHAR(255) NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Index for fast key lookups during authentication
+CREATE INDEX IF NOT EXISTS idx_api_keys_key_hash ON api_keys(key_hash);

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -3,7 +3,7 @@ const http = require('http');
 const path = require('path');
 const socketIo = require('socket.io');
 const { Pool } = require('pg');
-const { createApiRouter } = require('./api');
+const { createApiRouter, generateDocs } = require('./api');
 // Create Express app and HTTP server
 const app = express();
 const server = http.createServer(app);
@@ -54,6 +54,12 @@ app.use(express.json());
 // Health check endpoint - must come before other routes
 app.get('/health', (req, res) => {
   res.status(200).json({ status: 'ok', timestamp: new Date().toISOString() });
+});
+
+// llms.txt — AI-readable API documentation
+app.get('/llms.txt', (req, res) => {
+  const baseUrl = `${req.protocol}://${req.get('host')}`;
+  res.type('text/markdown').send(generateDocs(baseUrl));
 });
 
 // REST API for agent/bot access

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -3,6 +3,7 @@ const http = require('http');
 const path = require('path');
 const socketIo = require('socket.io');
 const { Pool } = require('pg');
+const { createApiRouter } = require('./api');
 // Create Express app and HTTP server
 const app = express();
 const server = http.createServer(app);
@@ -47,10 +48,16 @@ initializeDatabase();
 // Debug current environment
 console.log(`Current NODE_ENV: "${process.env.NODE_ENV}"`);
 
+// Parse JSON request bodies (needed for REST API)
+app.use(express.json());
+
 // Health check endpoint - must come before other routes
 app.get('/health', (req, res) => {
   res.status(200).json({ status: 'ok', timestamp: new Date().toISOString() });
 });
+
+// REST API for agent/bot access
+app.use('/api', createApiRouter(pool, io));
 
 // Serve static files from the 'dist' folder (production build)
 app.use(express.static(path.join(__dirname, '..', '..', 'dist')));
@@ -168,5 +175,5 @@ server.listen(PORT, HOST, () => {
 
 // Export for testing
 if (process.env.NODE_ENV === 'test') {
-  module.exports = { setupSocketHandlers, pool };
+  module.exports = { setupSocketHandlers, pool, app };
 }

--- a/tests/ServerSidebar.test.js
+++ b/tests/ServerSidebar.test.js
@@ -213,4 +213,13 @@ describe('ServerSidebar.vue', () => {
     const wrapper = shallowMount(ServerSidebar);
     expect(wrapper.vm.clerkReady).toBe(false);
   });
+
+  test('renders API docs link', () => {
+    const wrapper = shallowMount(ServerSidebar);
+
+    const docsLink = wrapper.find('[data-testid="api-docs-link"]');
+    expect(docsLink.exists()).toBe(true);
+    expect(docsLink.attributes('href')).toBe('/api/docs');
+    expect(docsLink.attributes('target')).toBe('_blank');
+  });
 });

--- a/tests/ServerSidebar.test.js
+++ b/tests/ServerSidebar.test.js
@@ -219,7 +219,7 @@ describe('ServerSidebar.vue', () => {
 
     const docsLink = wrapper.find('[data-testid="api-docs-link"]');
     expect(docsLink.exists()).toBe(true);
-    expect(docsLink.attributes('href')).toBe('/api/docs');
+    expect(docsLink.attributes('href')).toBe('/llms.txt');
     expect(docsLink.attributes('target')).toBe('_blank');
   });
 });

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -3,7 +3,7 @@
  */
 const express = require('express');
 const request = require('supertest');
-const { createApiRouter } = require('../src/server/api');
+const { createApiRouter, generateDocs } = require('../src/server/api');
 const { hashKey } = require('../src/server/auth');
 
 // Helpers -------------------------------------------------------------------
@@ -295,49 +295,44 @@ describe('REST API — POST /api/messages', () => {
 });
 
 // ---------------------------------------------------------------------------
-// API documentation endpoint
+// generateDocs
 // ---------------------------------------------------------------------------
 
-describe('REST API — GET /api/docs', () => {
-  test('returns markdown documentation without auth', async () => {
-    const app = buildApp(authedMockPool(), defaultMockIo());
-    const res = await request(app).get('/api/docs');
+describe('generateDocs', () => {
+  test('returns markdown with all sections', () => {
+    const md = generateDocs('https://nilo.chat');
 
-    expect(res.status).toBe(200);
-    expect(res.headers['content-type']).toMatch(/text\/markdown/);
-    expect(res.text).toContain('# nilo.chat API');
+    expect(md).toContain('# nilo.chat API');
+    expect(md).toContain('## Getting Started');
+    expect(md).toContain('## Endpoints');
+    expect(md).toContain('## Channels');
   });
 
-  test('includes getting started steps', async () => {
-    const app = buildApp(authedMockPool(), defaultMockIo());
-    const res = await request(app).get('/api/docs');
+  test('includes base URL in examples', () => {
+    const md = generateDocs('https://nilo.chat');
 
-    expect(res.text).toContain('## Getting Started');
-    expect(res.text).toContain('POST');
-    expect(res.text).toContain('/api/keys');
-    expect(res.text).toContain('x-api-key');
+    expect(md).toContain('https://nilo.chat/api/keys');
+    expect(md).toContain('https://nilo.chat/api/channels');
+    expect(md).toContain('https://nilo.chat/api/messages');
   });
 
-  test('documents all endpoints', async () => {
-    const app = buildApp(authedMockPool(), defaultMockIo());
-    const res = await request(app).get('/api/docs');
+  test('documents all endpoints', () => {
+    const md = generateDocs('http://localhost:3000');
 
-    expect(res.text).toContain('### POST /api/keys');
-    expect(res.text).toContain('### DELETE /api/keys/:id');
-    expect(res.text).toContain('### GET /api/channels');
-    expect(res.text).toContain('### GET /api/messages/:channel');
-    expect(res.text).toContain('### POST /api/messages');
+    expect(md).toContain('### POST /api/keys');
+    expect(md).toContain('### DELETE /api/keys/:id');
+    expect(md).toContain('### GET /api/channels');
+    expect(md).toContain('### GET /api/messages/:channel');
+    expect(md).toContain('### POST /api/messages');
   });
 
-  test('includes channel table', async () => {
-    const app = buildApp(authedMockPool(), defaultMockIo());
-    const res = await request(app).get('/api/docs');
+  test('includes all channel descriptions', () => {
+    const md = generateDocs('https://nilo.chat');
 
-    expect(res.text).toContain('## Channels');
-    expect(res.text).toContain('| welcome |');
-    expect(res.text).toContain('| general |');
-    expect(res.text).toContain('| growth |');
-    expect(res.text).toContain('| feedback |');
+    expect(md).toContain('| welcome |');
+    expect(md).toContain('| general |');
+    expect(md).toContain('| growth |');
+    expect(md).toContain('| feedback |');
   });
 });
 

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,0 +1,203 @@
+/**
+ * @jest-environment node
+ */
+const express = require('express');
+const request = require('supertest');
+const { createApiRouter } = require('../src/server/api');
+
+// Helpers -------------------------------------------------------------------
+
+function buildApp(mockPool, mockIo) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createApiRouter(mockPool, mockIo));
+  return app;
+}
+
+function defaultMockPool() {
+  return {
+    query: jest.fn().mockResolvedValue({ rows: [] }),
+  };
+}
+
+function defaultMockIo() {
+  return { emit: jest.fn() };
+}
+
+// Tests ---------------------------------------------------------------------
+
+describe('REST API — /api/channels', () => {
+  test('returns all channels with descriptions', async () => {
+    const app = buildApp(defaultMockPool(), defaultMockIo());
+    const res = await request(app).get('/api/channels');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(4);
+    expect(res.body[0]).toEqual({
+      name: 'welcome',
+      description: 'Say hi — no account needed.',
+    });
+    expect(res.body.map((c) => c.name)).toEqual(['welcome', 'general', 'growth', 'feedback']);
+  });
+});
+
+describe('REST API — GET /api/messages/:channel', () => {
+  test('returns messages for a valid channel', async () => {
+    const mockRows = [
+      { timestamp: '2026-01-01T00:00:00Z', username: 'Alice', message: 'Hi', channel: 'general' },
+      { timestamp: '2026-01-01T00:01:00Z', username: 'Bob', message: 'Hey', channel: 'general' },
+    ];
+    const pool = defaultMockPool();
+    // The API fetches DESC and then reverses, so mock returns DESC order
+    pool.query.mockResolvedValue({ rows: [...mockRows].reverse() });
+
+    const app = buildApp(pool, defaultMockIo());
+    const res = await request(app).get('/api/messages/general');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    // API fetches DESC then reverses → chronological (oldest first)
+    expect(res.body[0].username).toBe('Alice');
+    expect(res.body[1].username).toBe('Bob');
+
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT'),
+      ['general', 50] // default limit
+    );
+  });
+
+  test('rejects invalid channel', async () => {
+    const app = buildApp(defaultMockPool(), defaultMockIo());
+    const res = await request(app).get('/api/messages/invalid');
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Invalid channel/);
+  });
+
+  test('clamps limit to MAX_LIMIT', async () => {
+    const pool = defaultMockPool();
+    const app = buildApp(pool, defaultMockIo());
+    await request(app).get('/api/messages/general?limit=999');
+
+    expect(pool.query).toHaveBeenCalledWith(expect.any(String), ['general', 200]);
+  });
+
+  test('uses default limit for invalid value', async () => {
+    const pool = defaultMockPool();
+    const app = buildApp(pool, defaultMockIo());
+    await request(app).get('/api/messages/general?limit=abc');
+
+    expect(pool.query).toHaveBeenCalledWith(expect.any(String), ['general', 50]);
+  });
+
+  test('handles database error gracefully', async () => {
+    const pool = defaultMockPool();
+    pool.query.mockRejectedValue(new Error('DB down'));
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    const app = buildApp(pool, defaultMockIo());
+    const res = await request(app).get('/api/messages/general');
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Failed to read messages');
+
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('REST API — POST /api/messages', () => {
+  test('creates a message and broadcasts via Socket.IO', async () => {
+    const pool = defaultMockPool();
+    const io = defaultMockIo();
+    const app = buildApp(pool, io);
+
+    const res = await request(app)
+      .post('/api/messages')
+      .send({ channel: 'general', message: 'Hello API!', username: 'TestBot' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.message).toBe('Hello API!');
+    expect(res.body.username).toBe('TestBot');
+    expect(res.body.channel).toBe('general');
+    expect(res.body.timestamp).toBeDefined();
+
+    // Verify DB insert
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO messages'),
+      expect.arrayContaining(['TestBot', 'Hello API!', 'general'])
+    );
+
+    // Verify Socket.IO broadcast
+    expect(io.emit).toHaveBeenCalledWith('chat_message', expect.objectContaining({
+      message: 'Hello API!',
+      username: 'TestBot',
+      channel: 'general',
+    }));
+  });
+
+  test('rejects missing channel', async () => {
+    const app = buildApp(defaultMockPool(), defaultMockIo());
+    const res = await request(app)
+      .post('/api/messages')
+      .send({ message: 'Hi', username: 'Bot' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Invalid channel/);
+  });
+
+  test('rejects invalid channel', async () => {
+    const app = buildApp(defaultMockPool(), defaultMockIo());
+    const res = await request(app)
+      .post('/api/messages')
+      .send({ channel: 'nope', message: 'Hi', username: 'Bot' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Invalid channel/);
+  });
+
+  test('rejects empty message', async () => {
+    const app = buildApp(defaultMockPool(), defaultMockIo());
+    const res = await request(app)
+      .post('/api/messages')
+      .send({ channel: 'general', message: '', username: 'Bot' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Message cannot be empty');
+  });
+
+  test('rejects message exceeding max length', async () => {
+    const app = buildApp(defaultMockPool(), defaultMockIo());
+    const res = await request(app)
+      .post('/api/messages')
+      .send({ channel: 'general', message: 'a'.repeat(2001), username: 'Bot' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/maximum length/);
+  });
+
+  test('rejects missing username', async () => {
+    const app = buildApp(defaultMockPool(), defaultMockIo());
+    const res = await request(app)
+      .post('/api/messages')
+      .send({ channel: 'general', message: 'Hi' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Username is required');
+  });
+
+  test('handles database error gracefully', async () => {
+    const pool = defaultMockPool();
+    pool.query.mockRejectedValue(new Error('DB write fail'));
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    const app = buildApp(pool, defaultMockIo());
+    const res = await request(app)
+      .post('/api/messages')
+      .send({ channel: 'general', message: 'Hi', username: 'Bot' });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Failed to save message');
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -299,41 +299,45 @@ describe('REST API — POST /api/messages', () => {
 // ---------------------------------------------------------------------------
 
 describe('REST API — GET /api/docs', () => {
-  test('returns API documentation without auth', async () => {
+  test('returns markdown documentation without auth', async () => {
     const app = buildApp(authedMockPool(), defaultMockIo());
     const res = await request(app).get('/api/docs');
 
     expect(res.status).toBe(200);
-    expect(res.body.name).toBe('nilo.chat');
-    expect(res.body.description).toBeDefined();
-    expect(res.body.getting_started).toBeDefined();
-    expect(res.body.endpoints).toBeInstanceOf(Array);
-    expect(res.body.endpoints.length).toBe(5);
-    expect(res.body.channels).toBeInstanceOf(Array);
-    expect(res.body.channels.length).toBe(4);
+    expect(res.headers['content-type']).toMatch(/text\/markdown/);
+    expect(res.text).toContain('# nilo.chat API');
   });
 
-  test('includes all endpoint methods and paths', async () => {
+  test('includes getting started steps', async () => {
     const app = buildApp(authedMockPool(), defaultMockIo());
     const res = await request(app).get('/api/docs');
 
-    const paths = res.body.endpoints.map((e) => `${e.method} ${e.path}`);
-    expect(paths).toContain('POST /api/keys');
-    expect(paths).toContain('DELETE /api/keys/:id');
-    expect(paths).toContain('GET /api/channels');
-    expect(paths).toContain('GET /api/messages/:channel');
-    expect(paths).toContain('POST /api/messages');
+    expect(res.text).toContain('## Getting Started');
+    expect(res.text).toContain('POST');
+    expect(res.text).toContain('/api/keys');
+    expect(res.text).toContain('x-api-key');
   });
 
-  test('includes channel names and descriptions', async () => {
+  test('documents all endpoints', async () => {
     const app = buildApp(authedMockPool(), defaultMockIo());
     const res = await request(app).get('/api/docs');
 
-    const channelNames = res.body.channels.map((c) => c.name);
-    expect(channelNames).toEqual(['welcome', 'general', 'growth', 'feedback']);
-    res.body.channels.forEach((c) => {
-      expect(c.description).toBeDefined();
-    });
+    expect(res.text).toContain('### POST /api/keys');
+    expect(res.text).toContain('### DELETE /api/keys/:id');
+    expect(res.text).toContain('### GET /api/channels');
+    expect(res.text).toContain('### GET /api/messages/:channel');
+    expect(res.text).toContain('### POST /api/messages');
+  });
+
+  test('includes channel table', async () => {
+    const app = buildApp(authedMockPool(), defaultMockIo());
+    const res = await request(app).get('/api/docs');
+
+    expect(res.text).toContain('## Channels');
+    expect(res.text).toContain('| welcome |');
+    expect(res.text).toContain('| general |');
+    expect(res.text).toContain('| growth |');
+    expect(res.text).toContain('| feedback |');
   });
 });
 

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -4,9 +4,15 @@
 const express = require('express');
 const request = require('supertest');
 const { createApiRouter } = require('../src/server/api');
+const { hashKey } = require('../src/server/auth');
 
 // Helpers -------------------------------------------------------------------
 
+const VALID_KEY = 'test-agent-key-abc123';
+const VALID_KEY_HASH = hashKey(VALID_KEY);
+const ADMIN_KEY = 'test-admin-secret';
+
+/** Build an Express app with the API router mounted. */
 function buildApp(mockPool, mockIo) {
   const app = express();
   app.use(express.json());
@@ -14,22 +20,70 @@ function buildApp(mockPool, mockIo) {
   return app;
 }
 
-function defaultMockPool() {
-  return {
-    query: jest.fn().mockResolvedValue({ rows: [] }),
+/**
+ * Mock pool that returns a valid agent row when the auth middleware looks up
+ * an API key, and empty rows for everything else by default.
+ */
+function authedMockPool() {
+  const pool = {
+    query: jest.fn((sql, params) => {
+      // Auth middleware SELECT for api_keys
+      if (sql.includes('SELECT') && sql.includes('api_keys') && params && params[0] === VALID_KEY_HASH) {
+        return Promise.resolve({
+          rows: [{ id: 1, agent_name: 'TestBot', created_at: '2026-01-01' }],
+        });
+      }
+      return Promise.resolve({ rows: [] });
+    }),
   };
+  return pool;
 }
 
 function defaultMockIo() {
   return { emit: jest.fn() };
 }
 
-// Tests ---------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// Auth enforcement
+// ---------------------------------------------------------------------------
+
+describe('REST API — auth enforcement', () => {
+  test('returns 401 for chat endpoints without API key', async () => {
+    const app = buildApp(authedMockPool(), defaultMockIo());
+
+    const channelsRes = await request(app).get('/api/channels');
+    expect(channelsRes.status).toBe(401);
+
+    const messagesRes = await request(app).get('/api/messages/general');
+    expect(messagesRes.status).toBe(401);
+
+    const postRes = await request(app)
+      .post('/api/messages')
+      .send({ channel: 'general', message: 'Hi', username: 'Bot' });
+    expect(postRes.status).toBe(401);
+  });
+
+  test('returns 401 for invalid API key', async () => {
+    const app = buildApp(authedMockPool(), defaultMockIo());
+
+    const res = await request(app)
+      .get('/api/channels')
+      .set('x-api-key', 'wrong-key');
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Invalid API key');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chat endpoints (with valid API key)
+// ---------------------------------------------------------------------------
 
 describe('REST API — /api/channels', () => {
   test('returns all channels with descriptions', async () => {
-    const app = buildApp(defaultMockPool(), defaultMockIo());
-    const res = await request(app).get('/api/channels');
+    const app = buildApp(authedMockPool(), defaultMockIo());
+    const res = await request(app)
+      .get('/api/channels')
+      .set('x-api-key', VALID_KEY);
 
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(4);
@@ -47,56 +101,80 @@ describe('REST API — GET /api/messages/:channel', () => {
       { timestamp: '2026-01-01T00:00:00Z', username: 'Alice', message: 'Hi', channel: 'general' },
       { timestamp: '2026-01-01T00:01:00Z', username: 'Bob', message: 'Hey', channel: 'general' },
     ];
-    const pool = defaultMockPool();
-    // The API fetches DESC and then reverses, so mock returns DESC order
-    pool.query.mockResolvedValue({ rows: [...mockRows].reverse() });
+    const pool = authedMockPool();
+    const originalQuery = pool.query;
+    pool.query = jest.fn((sql, params) => {
+      // Let auth pass, then return message rows for the SELECT messages query
+      if (sql.includes('SELECT') && sql.includes('messages')) {
+        return Promise.resolve({ rows: [...mockRows].reverse() });
+      }
+      return originalQuery(sql, params);
+    });
 
     const app = buildApp(pool, defaultMockIo());
-    const res = await request(app).get('/api/messages/general');
+    const res = await request(app)
+      .get('/api/messages/general')
+      .set('x-api-key', VALID_KEY);
 
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(2);
     // API fetches DESC then reverses → chronological (oldest first)
     expect(res.body[0].username).toBe('Alice');
     expect(res.body[1].username).toBe('Bob');
-
-    expect(pool.query).toHaveBeenCalledWith(
-      expect.stringContaining('SELECT'),
-      ['general', 50] // default limit
-    );
   });
 
   test('rejects invalid channel', async () => {
-    const app = buildApp(defaultMockPool(), defaultMockIo());
-    const res = await request(app).get('/api/messages/invalid');
+    const app = buildApp(authedMockPool(), defaultMockIo());
+    const res = await request(app)
+      .get('/api/messages/invalid')
+      .set('x-api-key', VALID_KEY);
 
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/Invalid channel/);
   });
 
   test('clamps limit to MAX_LIMIT', async () => {
-    const pool = defaultMockPool();
+    const pool = authedMockPool();
     const app = buildApp(pool, defaultMockIo());
-    await request(app).get('/api/messages/general?limit=999');
+    await request(app)
+      .get('/api/messages/general?limit=999')
+      .set('x-api-key', VALID_KEY);
 
-    expect(pool.query).toHaveBeenCalledWith(expect.any(String), ['general', 200]);
+    // Second call (after auth) is the messages query
+    const messageQuery = pool.query.mock.calls.find(
+      (c) => c[0].includes('messages') && c[0].includes('SELECT')
+    );
+    expect(messageQuery[1]).toEqual(['general', 200]);
   });
 
   test('uses default limit for invalid value', async () => {
-    const pool = defaultMockPool();
+    const pool = authedMockPool();
     const app = buildApp(pool, defaultMockIo());
-    await request(app).get('/api/messages/general?limit=abc');
+    await request(app)
+      .get('/api/messages/general?limit=abc')
+      .set('x-api-key', VALID_KEY);
 
-    expect(pool.query).toHaveBeenCalledWith(expect.any(String), ['general', 50]);
+    const messageQuery = pool.query.mock.calls.find(
+      (c) => c[0].includes('messages') && c[0].includes('SELECT')
+    );
+    expect(messageQuery[1]).toEqual(['general', 50]);
   });
 
   test('handles database error gracefully', async () => {
-    const pool = defaultMockPool();
-    pool.query.mockRejectedValue(new Error('DB down'));
+    const pool = authedMockPool();
+    const originalQuery = pool.query;
+    pool.query = jest.fn((sql, params) => {
+      if (sql.includes('SELECT') && sql.includes('messages')) {
+        return Promise.reject(new Error('DB down'));
+      }
+      return originalQuery(sql, params);
+    });
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
     const app = buildApp(pool, defaultMockIo());
-    const res = await request(app).get('/api/messages/general');
+    const res = await request(app)
+      .get('/api/messages/general')
+      .set('x-api-key', VALID_KEY);
 
     expect(res.status).toBe(500);
     expect(res.body.error).toBe('Failed to read messages');
@@ -107,12 +185,13 @@ describe('REST API — GET /api/messages/:channel', () => {
 
 describe('REST API — POST /api/messages', () => {
   test('creates a message and broadcasts via Socket.IO', async () => {
-    const pool = defaultMockPool();
+    const pool = authedMockPool();
     const io = defaultMockIo();
     const app = buildApp(pool, io);
 
     const res = await request(app)
       .post('/api/messages')
+      .set('x-api-key', VALID_KEY)
       .send({ channel: 'general', message: 'Hello API!', username: 'TestBot' });
 
     expect(res.status).toBe(201);
@@ -122,8 +201,9 @@ describe('REST API — POST /api/messages', () => {
     expect(res.body.timestamp).toBeDefined();
 
     // Verify DB insert
-    expect(pool.query).toHaveBeenCalledWith(
-      expect.stringContaining('INSERT INTO messages'),
+    const insertCall = pool.query.mock.calls.find((c) => c[0].includes('INSERT INTO messages'));
+    expect(insertCall).toBeDefined();
+    expect(insertCall[1]).toEqual(
       expect.arrayContaining(['TestBot', 'Hello API!', 'general'])
     );
 
@@ -136,9 +216,10 @@ describe('REST API — POST /api/messages', () => {
   });
 
   test('rejects missing channel', async () => {
-    const app = buildApp(defaultMockPool(), defaultMockIo());
+    const app = buildApp(authedMockPool(), defaultMockIo());
     const res = await request(app)
       .post('/api/messages')
+      .set('x-api-key', VALID_KEY)
       .send({ message: 'Hi', username: 'Bot' });
 
     expect(res.status).toBe(400);
@@ -146,9 +227,10 @@ describe('REST API — POST /api/messages', () => {
   });
 
   test('rejects invalid channel', async () => {
-    const app = buildApp(defaultMockPool(), defaultMockIo());
+    const app = buildApp(authedMockPool(), defaultMockIo());
     const res = await request(app)
       .post('/api/messages')
+      .set('x-api-key', VALID_KEY)
       .send({ channel: 'nope', message: 'Hi', username: 'Bot' });
 
     expect(res.status).toBe(400);
@@ -156,9 +238,10 @@ describe('REST API — POST /api/messages', () => {
   });
 
   test('rejects empty message', async () => {
-    const app = buildApp(defaultMockPool(), defaultMockIo());
+    const app = buildApp(authedMockPool(), defaultMockIo());
     const res = await request(app)
       .post('/api/messages')
+      .set('x-api-key', VALID_KEY)
       .send({ channel: 'general', message: '', username: 'Bot' });
 
     expect(res.status).toBe(400);
@@ -166,9 +249,10 @@ describe('REST API — POST /api/messages', () => {
   });
 
   test('rejects message exceeding max length', async () => {
-    const app = buildApp(defaultMockPool(), defaultMockIo());
+    const app = buildApp(authedMockPool(), defaultMockIo());
     const res = await request(app)
       .post('/api/messages')
+      .set('x-api-key', VALID_KEY)
       .send({ channel: 'general', message: 'a'.repeat(2001), username: 'Bot' });
 
     expect(res.status).toBe(400);
@@ -176,9 +260,10 @@ describe('REST API — POST /api/messages', () => {
   });
 
   test('rejects missing username', async () => {
-    const app = buildApp(defaultMockPool(), defaultMockIo());
+    const app = buildApp(authedMockPool(), defaultMockIo());
     const res = await request(app)
       .post('/api/messages')
+      .set('x-api-key', VALID_KEY)
       .send({ channel: 'general', message: 'Hi' });
 
     expect(res.status).toBe(400);
@@ -186,17 +271,265 @@ describe('REST API — POST /api/messages', () => {
   });
 
   test('handles database error gracefully', async () => {
-    const pool = defaultMockPool();
-    pool.query.mockRejectedValue(new Error('DB write fail'));
+    const pool = authedMockPool();
+    const originalQuery = pool.query;
+    pool.query = jest.fn((sql, params) => {
+      if (sql.includes('INSERT INTO messages')) {
+        return Promise.reject(new Error('DB write fail'));
+      }
+      return originalQuery(sql, params);
+    });
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
     const app = buildApp(pool, defaultMockIo());
     const res = await request(app)
       .post('/api/messages')
+      .set('x-api-key', VALID_KEY)
       .send({ channel: 'general', message: 'Hi', username: 'Bot' });
 
     expect(res.status).toBe(500);
     expect(res.body.error).toBe('Failed to save message');
+
+    consoleSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Key management endpoints
+// ---------------------------------------------------------------------------
+
+describe('REST API — POST /api/keys (create)', () => {
+  const originalAdminKey = process.env.ADMIN_API_KEY;
+  beforeEach(() => { process.env.ADMIN_API_KEY = ADMIN_KEY; });
+  afterEach(() => {
+    if (originalAdminKey === undefined) delete process.env.ADMIN_API_KEY;
+    else process.env.ADMIN_API_KEY = originalAdminKey;
+  });
+
+  test('creates a new API key and returns it once', async () => {
+    const pool = authedMockPool();
+    const originalQuery = pool.query;
+    pool.query = jest.fn((sql, params) => {
+      if (sql.includes('INSERT INTO api_keys')) {
+        return Promise.resolve({
+          rows: [{ id: 42, agent_name: 'NewAgent', created_at: '2026-02-19T00:00:00Z' }],
+        });
+      }
+      return originalQuery(sql, params);
+    });
+
+    const app = buildApp(pool, defaultMockIo());
+    const res = await request(app)
+      .post('/api/keys')
+      .set('x-api-key', ADMIN_KEY)
+      .send({ agent_name: 'NewAgent' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBe(42);
+    expect(res.body.agent_name).toBe('NewAgent');
+    expect(res.body.api_key).toBeDefined();
+    expect(res.body.api_key).toHaveLength(64); // 32 bytes hex
+    expect(res.body.created_at).toBeDefined();
+  });
+
+  test('rejects missing agent_name', async () => {
+    const app = buildApp(authedMockPool(), defaultMockIo());
+    const res = await request(app)
+      .post('/api/keys')
+      .set('x-api-key', ADMIN_KEY)
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('agent_name is required');
+  });
+
+  test('rejects empty agent_name', async () => {
+    const app = buildApp(authedMockPool(), defaultMockIo());
+    const res = await request(app)
+      .post('/api/keys')
+      .set('x-api-key', ADMIN_KEY)
+      .send({ agent_name: '   ' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('agent_name is required');
+  });
+
+  test('returns 403 with wrong admin key', async () => {
+    const app = buildApp(authedMockPool(), defaultMockIo());
+    const res = await request(app)
+      .post('/api/keys')
+      .set('x-api-key', 'wrong-admin-key')
+      .send({ agent_name: 'Agent' });
+
+    expect(res.status).toBe(403);
+  });
+
+  test('returns 401 with no key', async () => {
+    const app = buildApp(authedMockPool(), defaultMockIo());
+    const res = await request(app)
+      .post('/api/keys')
+      .send({ agent_name: 'Agent' });
+
+    expect(res.status).toBe(401);
+  });
+
+  test('handles database error', async () => {
+    const pool = authedMockPool();
+    const originalQuery = pool.query;
+    pool.query = jest.fn((sql, params) => {
+      if (sql.includes('INSERT INTO api_keys')) {
+        return Promise.reject(new Error('DB fail'));
+      }
+      return originalQuery(sql, params);
+    });
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    const app = buildApp(pool, defaultMockIo());
+    const res = await request(app)
+      .post('/api/keys')
+      .set('x-api-key', ADMIN_KEY)
+      .send({ agent_name: 'Agent' });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Failed to create API key');
+
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('REST API — DELETE /api/keys/:id', () => {
+  const originalAdminKey = process.env.ADMIN_API_KEY;
+  beforeEach(() => { process.env.ADMIN_API_KEY = ADMIN_KEY; });
+  afterEach(() => {
+    if (originalAdminKey === undefined) delete process.env.ADMIN_API_KEY;
+    else process.env.ADMIN_API_KEY = originalAdminKey;
+  });
+
+  test('deletes an existing key', async () => {
+    const pool = authedMockPool();
+    const originalQuery = pool.query;
+    pool.query = jest.fn((sql, params) => {
+      if (sql.includes('DELETE FROM api_keys')) {
+        return Promise.resolve({ rows: [{ id: 5, agent_name: 'OldBot' }] });
+      }
+      return originalQuery(sql, params);
+    });
+
+    const app = buildApp(pool, defaultMockIo());
+    const res = await request(app)
+      .delete('/api/keys/5')
+      .set('x-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.deleted).toEqual({ id: 5, agent_name: 'OldBot' });
+  });
+
+  test('returns 404 for non-existent key', async () => {
+    const app = buildApp(authedMockPool(), defaultMockIo());
+    const res = await request(app)
+      .delete('/api/keys/999')
+      .set('x-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('API key not found');
+  });
+
+  test('returns 400 for invalid id', async () => {
+    const app = buildApp(authedMockPool(), defaultMockIo());
+    const res = await request(app)
+      .delete('/api/keys/abc')
+      .set('x-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid key id');
+  });
+
+  test('handles database error', async () => {
+    const pool = authedMockPool();
+    const originalQuery = pool.query;
+    pool.query = jest.fn((sql, params) => {
+      if (sql.includes('DELETE FROM api_keys')) {
+        return Promise.reject(new Error('DB fail'));
+      }
+      return originalQuery(sql, params);
+    });
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    const app = buildApp(pool, defaultMockIo());
+    const res = await request(app)
+      .delete('/api/keys/1')
+      .set('x-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Failed to delete API key');
+
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('REST API — GET /api/keys (list)', () => {
+  const originalAdminKey = process.env.ADMIN_API_KEY;
+  beforeEach(() => { process.env.ADMIN_API_KEY = ADMIN_KEY; });
+  afterEach(() => {
+    if (originalAdminKey === undefined) delete process.env.ADMIN_API_KEY;
+    else process.env.ADMIN_API_KEY = originalAdminKey;
+  });
+
+  test('lists all keys without exposing secrets', async () => {
+    const pool = authedMockPool();
+    const originalQuery = pool.query;
+    pool.query = jest.fn((sql, params) => {
+      if (sql.includes('SELECT') && sql.includes('api_keys') && sql.includes('ORDER BY')) {
+        return Promise.resolve({
+          rows: [
+            { id: 1, agent_name: 'Bot1', created_at: '2026-01-01' },
+            { id: 2, agent_name: 'Bot2', created_at: '2026-01-02' },
+          ],
+        });
+      }
+      return originalQuery(sql, params);
+    });
+
+    const app = buildApp(pool, defaultMockIo());
+    const res = await request(app)
+      .get('/api/keys')
+      .set('x-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body[0].agent_name).toBe('Bot1');
+    // No api_key or key_hash exposed
+    expect(res.body[0].api_key).toBeUndefined();
+    expect(res.body[0].key_hash).toBeUndefined();
+  });
+
+  test('returns 403 without admin key', async () => {
+    const app = buildApp(authedMockPool(), defaultMockIo());
+    const res = await request(app)
+      .get('/api/keys')
+      .set('x-api-key', 'not-admin');
+
+    expect(res.status).toBe(403);
+  });
+
+  test('handles database error', async () => {
+    const pool = authedMockPool();
+    const originalQuery = pool.query;
+    pool.query = jest.fn((sql, params) => {
+      if (sql.includes('SELECT') && sql.includes('api_keys') && sql.includes('ORDER BY')) {
+        return Promise.reject(new Error('DB fail'));
+      }
+      return originalQuery(sql, params);
+    });
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    const app = buildApp(pool, defaultMockIo());
+    const res = await request(app)
+      .get('/api/keys')
+      .set('x-api-key', ADMIN_KEY);
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Failed to list API keys');
 
     consoleSpy.mockRestore();
   });

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -295,6 +295,49 @@ describe('REST API — POST /api/messages', () => {
 });
 
 // ---------------------------------------------------------------------------
+// API documentation endpoint
+// ---------------------------------------------------------------------------
+
+describe('REST API — GET /api/docs', () => {
+  test('returns API documentation without auth', async () => {
+    const app = buildApp(authedMockPool(), defaultMockIo());
+    const res = await request(app).get('/api/docs');
+
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('nilo.chat');
+    expect(res.body.description).toBeDefined();
+    expect(res.body.getting_started).toBeDefined();
+    expect(res.body.endpoints).toBeInstanceOf(Array);
+    expect(res.body.endpoints.length).toBe(5);
+    expect(res.body.channels).toBeInstanceOf(Array);
+    expect(res.body.channels.length).toBe(4);
+  });
+
+  test('includes all endpoint methods and paths', async () => {
+    const app = buildApp(authedMockPool(), defaultMockIo());
+    const res = await request(app).get('/api/docs');
+
+    const paths = res.body.endpoints.map((e) => `${e.method} ${e.path}`);
+    expect(paths).toContain('POST /api/keys');
+    expect(paths).toContain('DELETE /api/keys/:id');
+    expect(paths).toContain('GET /api/channels');
+    expect(paths).toContain('GET /api/messages/:channel');
+    expect(paths).toContain('POST /api/messages');
+  });
+
+  test('includes channel names and descriptions', async () => {
+    const app = buildApp(authedMockPool(), defaultMockIo());
+    const res = await request(app).get('/api/docs');
+
+    const channelNames = res.body.channels.map((c) => c.name);
+    expect(channelNames).toEqual(['welcome', 'general', 'growth', 'feedback']);
+    res.body.channels.forEach((c) => {
+      expect(c.description).toBeDefined();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Key management endpoints
 // ---------------------------------------------------------------------------
 

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,168 @@
+/**
+ * @jest-environment node
+ */
+const { hashKey, generateKey, requireApiKey, requireAdmin } = require('../src/server/auth');
+
+describe('auth — hashKey', () => {
+  test('returns a 64-char hex string', () => {
+    const hash = hashKey('test-key');
+    expect(hash).toHaveLength(64);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test('same input always produces same hash', () => {
+    expect(hashKey('abc')).toBe(hashKey('abc'));
+  });
+
+  test('different inputs produce different hashes', () => {
+    expect(hashKey('key-a')).not.toBe(hashKey('key-b'));
+  });
+});
+
+describe('auth — generateKey', () => {
+  test('returns a 64-char hex string', () => {
+    const key = generateKey();
+    expect(key).toHaveLength(64);
+    expect(key).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test('generates unique keys', () => {
+    const a = generateKey();
+    const b = generateKey();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('auth — requireApiKey middleware', () => {
+  function mockRes() {
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    return res;
+  }
+
+  test('returns 401 when x-api-key header is missing', async () => {
+    const pool = { query: jest.fn() };
+    const middleware = requireApiKey(pool);
+    const req = { headers: {} };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await middleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Missing x-api-key header' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('returns 401 when key is not found in DB', async () => {
+    const pool = { query: jest.fn().mockResolvedValue({ rows: [] }) };
+    const middleware = requireApiKey(pool);
+    const req = { headers: { 'x-api-key': 'bad-key' } };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await middleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid API key' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('calls next and sets req.agent when key is valid', async () => {
+    const agentRow = { id: 1, agent_name: 'TestBot', created_at: '2026-01-01' };
+    const pool = { query: jest.fn().mockResolvedValue({ rows: [agentRow] }) };
+    const middleware = requireApiKey(pool);
+    const req = { headers: { 'x-api-key': 'valid-key' } };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.agent).toEqual(agentRow);
+    // Verify the correct hash was looked up
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT'),
+      [hashKey('valid-key')]
+    );
+  });
+
+  test('returns 500 on database error', async () => {
+    const pool = { query: jest.fn().mockRejectedValue(new Error('DB down')) };
+    const middleware = requireApiKey(pool);
+    const req = { headers: { 'x-api-key': 'some-key' } };
+    const res = mockRes();
+    const next = jest.fn();
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    await middleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Authentication error' });
+    expect(next).not.toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('auth — requireAdmin middleware', () => {
+  function mockRes() {
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    return res;
+  }
+
+  const originalEnv = process.env.ADMIN_API_KEY;
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.ADMIN_API_KEY;
+    } else {
+      process.env.ADMIN_API_KEY = originalEnv;
+    }
+  });
+
+  test('returns 503 when ADMIN_API_KEY is not set', () => {
+    delete process.env.ADMIN_API_KEY;
+    const req = { headers: { 'x-api-key': 'anything' } };
+    const res = mockRes();
+    const next = jest.fn();
+
+    requireAdmin(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('returns 401 when x-api-key header is missing', () => {
+    process.env.ADMIN_API_KEY = 'admin-secret';
+    const req = { headers: {} };
+    const res = mockRes();
+    const next = jest.fn();
+
+    requireAdmin(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('returns 403 when key does not match ADMIN_API_KEY', () => {
+    process.env.ADMIN_API_KEY = 'admin-secret';
+    const req = { headers: { 'x-api-key': 'wrong-key' } };
+    const res = mockRes();
+    const next = jest.fn();
+
+    requireAdmin(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('calls next when key matches ADMIN_API_KEY', () => {
+    process.env.ADMIN_API_KEY = 'admin-secret';
+    const req = { headers: { 'x-api-key': 'admin-secret' } };
+    const res = mockRes();
+    const next = jest.fn();
+
+    requireAdmin(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/tests/bot-client.test.js
+++ b/tests/bot-client.test.js
@@ -1,0 +1,296 @@
+/**
+ * @jest-environment node
+ */
+const { NiloBotClient, CHANNELS } = require('../src/server/bot-client');
+
+// Mock socket.io-client
+const mockSocket = {
+  on: jest.fn(),
+  emit: jest.fn(),
+  disconnect: jest.fn(),
+};
+
+jest.mock('socket.io-client', () => ({
+  io: jest.fn(() => mockSocket),
+}));
+
+const { io: mockIo } = require('socket.io-client');
+
+describe('NiloBotClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset on to store callbacks
+    mockSocket.on.mockImplementation(() => mockSocket);
+  });
+
+  test('throws if serverUrl is missing', () => {
+    expect(() => new NiloBotClient(null, 'Bot')).toThrow('serverUrl is required');
+  });
+
+  test('throws if username is missing', () => {
+    expect(() => new NiloBotClient('http://localhost:3000', '')).toThrow('username is required');
+  });
+
+  test('connect() resolves on successful connection', async () => {
+    // Capture callbacks registered via socket.on
+    const callbacks = {};
+    mockSocket.on.mockImplementation((event, fn) => {
+      callbacks[event] = fn;
+      return mockSocket;
+    });
+
+    const bot = new NiloBotClient('http://localhost:3000', 'TestBot');
+    const connectPromise = bot.connect();
+
+    // Simulate connection
+    callbacks.connect();
+
+    await connectPromise;
+
+    expect(bot.connected).toBe(true);
+    expect(mockSocket.emit).toHaveBeenCalledWith('user_connected', {
+      username: 'TestBot',
+      channel: 'general',
+    });
+  });
+
+  test('connect() rejects on connection error before connected', async () => {
+    const callbacks = {};
+    mockSocket.on.mockImplementation((event, fn) => {
+      callbacks[event] = fn;
+      return mockSocket;
+    });
+
+    const bot = new NiloBotClient('http://localhost:3000', 'TestBot');
+    const connectPromise = bot.connect();
+
+    // Simulate connection error
+    callbacks.connect_error(new Error('refused'));
+
+    await expect(connectPromise).rejects.toThrow('Connection failed: refused');
+  });
+
+  test('sendMessage emits chat_message', async () => {
+    const callbacks = {};
+    mockSocket.on.mockImplementation((event, fn) => {
+      callbacks[event] = fn;
+      return mockSocket;
+    });
+
+    const bot = new NiloBotClient('http://localhost:3000', 'TestBot');
+    const connectPromise = bot.connect();
+    callbacks.connect();
+    await connectPromise;
+
+    mockSocket.emit.mockClear();
+
+    bot.sendMessage('general', 'Hello!');
+
+    expect(mockSocket.emit).toHaveBeenCalledWith('chat_message', {
+      username: 'TestBot',
+      message: 'Hello!',
+      channel: 'general',
+    });
+  });
+
+  test('sendMessage throws for invalid channel', async () => {
+    const callbacks = {};
+    mockSocket.on.mockImplementation((event, fn) => {
+      callbacks[event] = fn;
+      return mockSocket;
+    });
+
+    const bot = new NiloBotClient('http://localhost:3000', 'TestBot');
+    const connectPromise = bot.connect();
+    callbacks.connect();
+    await connectPromise;
+
+    expect(() => bot.sendMessage('invalid-channel', 'Hi')).toThrow('Invalid channel');
+  });
+
+  test('sendMessage throws when not connected', () => {
+    const bot = new NiloBotClient('http://localhost:3000', 'TestBot');
+    expect(() => bot.sendMessage('general', 'Hi')).toThrow('Not connected');
+  });
+
+  test('joinChannel emits join_channel and updates currentChannel', async () => {
+    const callbacks = {};
+    mockSocket.on.mockImplementation((event, fn) => {
+      callbacks[event] = fn;
+      return mockSocket;
+    });
+
+    const bot = new NiloBotClient('http://localhost:3000', 'TestBot');
+    const connectPromise = bot.connect();
+    callbacks.connect();
+    await connectPromise;
+
+    mockSocket.emit.mockClear();
+
+    bot.joinChannel('feedback');
+
+    expect(bot.currentChannel).toBe('feedback');
+    expect(mockSocket.emit).toHaveBeenCalledWith('join_channel', { channel: 'feedback' });
+  });
+
+  test('joinChannel throws for invalid channel', async () => {
+    const callbacks = {};
+    mockSocket.on.mockImplementation((event, fn) => {
+      callbacks[event] = fn;
+      return mockSocket;
+    });
+
+    const bot = new NiloBotClient('http://localhost:3000', 'TestBot');
+    const connectPromise = bot.connect();
+    callbacks.connect();
+    await connectPromise;
+
+    expect(() => bot.joinChannel('nope')).toThrow('Invalid channel');
+  });
+
+  test('onMessage receives incoming messages', async () => {
+    const callbacks = {};
+    mockSocket.on.mockImplementation((event, fn) => {
+      callbacks[event] = fn;
+      return mockSocket;
+    });
+
+    const bot = new NiloBotClient('http://localhost:3000', 'TestBot');
+    const received = [];
+    bot.onMessage((msg) => received.push(msg));
+
+    const connectPromise = bot.connect();
+    callbacks.connect();
+    await connectPromise;
+
+    const testMsg = { username: 'User1', message: 'Hi', channel: 'general', timestamp: '2026-01-01T00:00:00Z' };
+    callbacks.chat_message(testMsg);
+
+    expect(received).toEqual([testMsg]);
+  });
+
+  test('onHistory receives history payloads', async () => {
+    const callbacks = {};
+    mockSocket.on.mockImplementation((event, fn) => {
+      callbacks[event] = fn;
+      return mockSocket;
+    });
+
+    const bot = new NiloBotClient('http://localhost:3000', 'TestBot');
+    const received = [];
+    bot.onHistory((h) => received.push(h));
+
+    const connectPromise = bot.connect();
+    callbacks.connect();
+    await connectPromise;
+
+    callbacks.message_history(['msg1', 'msg2']);
+
+    expect(received).toEqual([['msg1', 'msg2']]);
+  });
+
+  test('onError receives error payloads', async () => {
+    const callbacks = {};
+    mockSocket.on.mockImplementation((event, fn) => {
+      callbacks[event] = fn;
+      return mockSocket;
+    });
+
+    const bot = new NiloBotClient('http://localhost:3000', 'TestBot');
+    const received = [];
+    bot.onError((e) => received.push(e));
+
+    const connectPromise = bot.connect();
+    callbacks.connect();
+    await connectPromise;
+
+    callbacks.error({ message: 'oops' });
+
+    expect(received).toEqual([{ message: 'oops' }]);
+  });
+
+  test('disconnect closes the socket', async () => {
+    const callbacks = {};
+    mockSocket.on.mockImplementation((event, fn) => {
+      callbacks[event] = fn;
+      return mockSocket;
+    });
+
+    const bot = new NiloBotClient('http://localhost:3000', 'TestBot');
+    const connectPromise = bot.connect();
+    callbacks.connect();
+    await connectPromise;
+
+    bot.disconnect();
+
+    expect(mockSocket.disconnect).toHaveBeenCalled();
+    expect(bot.connected).toBe(false);
+  });
+
+  test('sendMessage switches channel when different from current', async () => {
+    const callbacks = {};
+    mockSocket.on.mockImplementation((event, fn) => {
+      callbacks[event] = fn;
+      return mockSocket;
+    });
+
+    const bot = new NiloBotClient('http://localhost:3000', 'TestBot');
+    const connectPromise = bot.connect();
+    callbacks.connect();
+    await connectPromise;
+
+    mockSocket.emit.mockClear();
+
+    // Currently on 'general', send to 'feedback'
+    bot.sendMessage('feedback', 'Switching!');
+
+    // Should have emitted join_channel first, then chat_message
+    expect(mockSocket.emit).toHaveBeenCalledWith('join_channel', { channel: 'feedback' });
+    expect(mockSocket.emit).toHaveBeenCalledWith('chat_message', {
+      username: 'TestBot',
+      message: 'Switching!',
+      channel: 'feedback',
+    });
+  });
+
+  test('CHANNELS exports the correct list', () => {
+    expect(CHANNELS).toEqual(['welcome', 'general', 'growth', 'feedback']);
+  });
+
+  test('uses custom initial channel from options', async () => {
+    const callbacks = {};
+    mockSocket.on.mockImplementation((event, fn) => {
+      callbacks[event] = fn;
+      return mockSocket;
+    });
+
+    const bot = new NiloBotClient('http://localhost:3000', 'TestBot', { channel: 'welcome' });
+    const connectPromise = bot.connect();
+    callbacks.connect();
+    await connectPromise;
+
+    expect(mockSocket.emit).toHaveBeenCalledWith('user_connected', {
+      username: 'TestBot',
+      channel: 'welcome',
+    });
+  });
+
+  test('disconnect on socket sets connected to false', async () => {
+    const callbacks = {};
+    mockSocket.on.mockImplementation((event, fn) => {
+      callbacks[event] = fn;
+      return mockSocket;
+    });
+
+    const bot = new NiloBotClient('http://localhost:3000', 'TestBot');
+    const connectPromise = bot.connect();
+    callbacks.connect();
+    await connectPromise;
+
+    expect(bot.connected).toBe(true);
+
+    // Simulate server-side disconnect
+    callbacks.disconnect();
+    expect(bot.connected).toBe(false);
+  });
+});

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -69,6 +69,7 @@ const mockSocketIo = jest.fn(() => {
 // Mock the API router module
 jest.mock('../src/server/api', () => ({
   createApiRouter: jest.fn(() => 'mock-api-router'),
+  generateDocs: jest.fn((baseUrl) => `# nilo.chat API\n\nDocs for ${baseUrl}`),
 }));
 
 // Mock express and socket.io
@@ -284,6 +285,19 @@ describe('Server Module - Comprehensive', () => {
     expect(mockExpressApp.use).toHaveBeenCalled();
   });
   
+  test('configures /llms.txt route that returns markdown docs', () => {
+    expect(mockExpressApp.get).toHaveBeenCalledWith('/llms.txt', expect.any(Function));
+
+    const handler = mockExpressApp.get.mock.calls.find(call => call[0] === '/llms.txt')[1];
+    const req = { protocol: 'https', get: jest.fn(() => 'nilo.chat') };
+    const res = { type: jest.fn().mockReturnThis(), send: jest.fn() };
+
+    handler(req, res);
+
+    expect(res.type).toHaveBeenCalledWith('text/markdown');
+    expect(res.send).toHaveBeenCalledWith(expect.stringContaining('# nilo.chat API'));
+  });
+
   test('configures express with health check and catch-all route', () => {
     // Verify health check route was configured
     expect(mockExpressApp.get).toHaveBeenCalledWith('/health', expect.any(Function));

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -66,10 +66,16 @@ const mockSocketIo = jest.fn(() => {
   return mockIO;
 });
 
+// Mock the API router module
+jest.mock('../src/server/api', () => ({
+  createApiRouter: jest.fn(() => 'mock-api-router'),
+}));
+
 // Mock express and socket.io
 jest.mock('express', () => {
   const mockExpress = jest.fn(() => mockExpressApp);
   mockExpress.static = jest.fn(() => mockStaticMiddleware);
+  mockExpress.json = jest.fn(() => 'json-middleware');
   return mockExpress;
 });
 


### PR DESCRIPTION
## Summary

This PR implements Phase 1 and Phase 2 of the OpenClaw agent integration plan, adding a REST API for programmatic access to nilo.chat and a reusable Socket.IO bot client for real-time messaging.

## Key Changes

### REST API (`src/server/api.js`)
- **Chat endpoints** (require valid agent API key):
  - `GET /api/channels` — list all channels with descriptions
  - `GET /api/messages/:channel` — retrieve recent messages (with configurable limit, max 200)
  - `POST /api/messages` — send a message to a channel and broadcast via Socket.IO
- **Key management endpoints**:
  - `POST /api/keys` — self-register a new API key (open, no auth required)
  - `DELETE /api/keys/:id` — revoke a key (agent can delete own, admin can delete any)
  - `GET /api/keys` — list all keys (admin-only)

### Authentication (`src/server/auth.js`)
- `hashKey()` — SHA-256 hash for API keys
- `generateKey()` — cryptographically random 64-char hex key generation
- `requireApiKey()` — middleware that validates `x-api-key` header against database
- `requireAdmin()` — middleware that checks `ADMIN_API_KEY` environment variable

### Bot Client (`src/server/bot-client.js`)
- `NiloBotClient` class for connecting to nilo.chat as a bot via Socket.IO
- Methods: `connect()`, `sendMessage()`, `joinChannel()`, `onMessage()`, `onHistory()`, `onError()`, `disconnect()`
- Handles reconnection, channel switching, and event listeners
- Exports `CHANNELS` constant for valid channel names

### OpenClaw Skill (`skills/nilo-chat/`)
- `SKILL.md` — skill manifest declaring three tools for OpenClaw
- `index.js` — tool implementations for sending messages, reading messages, and listing channels
- Supports both REST API calls and optional persistent Socket.IO streaming

### Database
- Migration `002_create_api_keys_table.sql` — creates `api_keys` table with `key_hash`, `agent_name`, and `created_at` columns

### Tests
- `tests/api.test.js` — comprehensive REST API tests (auth enforcement, chat endpoints, key management, error handling)
- `tests/auth.test.js` — authentication middleware tests
- `tests/bot-client.test.js` — bot client lifecycle and messaging tests

### Integration
- Updated `src/server/index.js` to mount the API router at `/api`
- Updated `package.json` Jest config for Node.js test environment support

## Implementation Details

- API keys are stored as SHA-256 hashes; raw keys are returned only once at creation
- Message length capped at 2,000 characters; query limit capped at 200
- Bot client auto-switches channels when sending to a different channel
- All endpoints include proper error handling and logging
- Admin key management requires `ADMIN_API_KEY` environment variable

https://claude.ai/code/session_01RyUkqrpVgUhp4zNoiq8Vxd