### PR TITLE
Remove profile_image_url from messages table

### DIFF
--- a/src/server/db/migrations/002_add_profile_image_url.sql
+++ b/src/server/db/migrations/002_add_profile_image_url.sql
@@ -1,2 +1,0 @@
--- Add profile_image_url column to messages table
-ALTER TABLE messages ADD COLUMN IF NOT EXISTS profile_image_url TEXT DEFAULT NULL;

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -63,12 +63,12 @@ app.get('*', (req, res) => {
 async function sendMessageHistory(socket, channel) {
   try {
     const result = await pool.query(
-      'SELECT timestamp, username, message, profile_image_url FROM messages WHERE channel = $1 ORDER BY timestamp ASC',
+      'SELECT timestamp, username, message FROM messages WHERE channel = $1 ORDER BY timestamp ASC',
       [channel]
     );
 
     const history = result.rows.map(row =>
-      `${row.timestamp.toISOString()}|${row.username}|${row.profile_image_url || ''}|${row.message}`
+      `${row.timestamp.toISOString()}|${row.username}||${row.message}`
     );
 
     socket.emit('message_history', history);
@@ -127,8 +127,8 @@ function setupSocketHandlers(io) {
       // Save message to database
       try {
         await pool.query(
-          'INSERT INTO messages (timestamp, username, message, channel, profile_image_url) VALUES ($1, $2, $3, $4, $5)',
-          [timestamp, data.username, data.message, channel, data.profileImageUrl || null]
+          'INSERT INTO messages (timestamp, username, message, channel) VALUES ($1, $2, $3, $4)',
+          [timestamp, data.username, data.message, channel]
         );
 
         // Create message object with channel explicitly included


### PR DESCRIPTION
## Summary
This PR removes the `profile_image_url` column from the messages table and all related code that references it. This simplifies the message storage model by eliminating the profile image URL field.

## Key Changes
- Removed `profile_image_url` column from the SELECT query in `sendMessageHistory()` function
- Updated message history formatting to remove the profile image URL field from the pipe-delimited output
- Removed `profile_image_url` parameter from the INSERT query in the message save operation
- Deleted the migration file that added the `profile_image_url` column to the messages table

## Implementation Details
- The message history format now uses an empty field (`||`) where the profile image URL previously existed, maintaining backward compatibility with the pipe-delimited format
- The database INSERT statement now only stores timestamp, username, message, and channel information
- This change reduces the data footprint of stored messages and simplifies the message schema

https://claude.ai/code/session_01SF5boWvKk2qx4U4uszWmmS