### PR TITLE
Fix message box not visible on mobile by using dynamic viewport height

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-screen overflow-hidden" style="background: #edf2f7;">
+  <div class="h-screen-safe overflow-hidden" style="background: #edf2f7;">
     <ChatLayout />
   </div>
 </template>

--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -3,5 +3,10 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Global styles */
-/* Add your custom styles below */ 
+/* Use dynamic viewport height so the layout accounts for mobile browser chrome */
+@layer utilities {
+  .h-screen-safe {
+    height: 100vh;
+    height: 100dvh;
+  }
+} 

--- a/src/components/ChatLayout.vue
+++ b/src/components/ChatLayout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="font-sans antialiased h-screen flex w-full">
+  <div class="font-sans antialiased h-screen-safe flex w-full">
     <!-- Sidebar / channel list -->
     <ServerSidebar
       :current-channel="currentChannel"

--- a/tests/App.test.js
+++ b/tests/App.test.js
@@ -17,7 +17,7 @@ describe('App.vue', () => {
     // Check if it has the expected div with correct styling
     const rootDiv = wrapper.find('div');
     expect(rootDiv.exists()).toBe(true);
-    expect(rootDiv.classes()).toContain('h-screen');
+    expect(rootDiv.classes()).toContain('h-screen-safe');
     expect(rootDiv.classes()).toContain('overflow-hidden');
     expect(rootDiv.attributes('style')).toBe('background: rgb(237, 242, 247);');
     

--- a/tests/ChatLayout.test.js
+++ b/tests/ChatLayout.test.js
@@ -69,7 +69,7 @@ describe('ChatLayout.vue', () => {
     expect(rootDiv.exists()).toBe(true);
     expect(rootDiv.classes()).toContain('font-sans');
     expect(rootDiv.classes()).toContain('antialiased');
-    expect(rootDiv.classes()).toContain('h-screen');
+    expect(rootDiv.classes()).toContain('h-screen-safe');
     expect(rootDiv.classes()).toContain('flex');
     expect(rootDiv.classes()).toContain('w-full');
 


### PR DESCRIPTION
Mobile browsers include the address bar and navigation in 100vh, pushing
the message input below the visible area. Replace h-screen (100vh) with
a custom h-screen-safe utility that uses 100dvh with a 100vh fallback.

https://claude.ai/code/session_01GfcW7FD1UNcKqPeEz3hJT4