### PR TITLE
Move LLM docs link from sidebar to HTML head metadata

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,9 @@
     rel="icon"
     href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>💬</text></svg>"
   >
+  <!-- LLM documentation links -->
+  <link rel="help" type="text/plain" href="/llms.txt" title="LLM API Documentation">
+  <link rel="llms" href="/llms.txt">
   <!-- Clerk.js -->
   <script
     async
@@ -24,6 +27,7 @@
   ></script>
 </head>
 <body>
+  <!-- AI agents: see /llms.txt for API documentation and instructions -->
   <noscript>
     <strong>We're sorry but nilo.chat doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
   </noscript>

--- a/src/components/ServerSidebar.vue
+++ b/src/components/ServerSidebar.vue
@@ -20,14 +20,6 @@
           </svg>
         </div>
       </a>
-
-      <a href="/llms.txt" target="_blank" class="cursor-pointer block" data-testid="api-docs-link">
-        <div class="bg-white opacity-25 h-12 w-12 flex items-center justify-center text-black text-2xl font-semibold rounded-lg mb-1 overflow-hidden hover:opacity-30 transition-opacity" title="API Docs">
-          <svg class="fill-current h-6 w-6 block" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-            <path d="M6 4H5a1 1 0 1 1 0-2h11V1a1 1 0 0 0-1-1H4a2 2 0 0 0-2 2v16c0 1.1.9 2 2 2h12a2 2 0 0 0 2-2V5a1 1 0 0 0-1-1h-7v8l-2-2-2 2V4z"/>
-          </svg>
-        </div>
-      </a>
     </div>
 
     <!-- Profile icon at bottom -->

--- a/tests/ServerSidebar.test.js
+++ b/tests/ServerSidebar.test.js
@@ -214,12 +214,10 @@ describe('ServerSidebar.vue', () => {
     expect(wrapper.vm.clerkReady).toBe(false);
   });
 
-  test('renders API docs link', () => {
+  test('does not render API docs link in sidebar', () => {
     const wrapper = shallowMount(ServerSidebar);
 
     const docsLink = wrapper.find('[data-testid="api-docs-link"]');
-    expect(docsLink.exists()).toBe(true);
-    expect(docsLink.attributes('href')).toBe('/llms.txt');
-    expect(docsLink.attributes('target')).toBe('_blank');
+    expect(docsLink.exists()).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Removed the API docs link from the ServerSidebar component and relocated the LLM documentation reference to the HTML document head as semantic metadata. This change makes the documentation discoverable to LLM agents and crawlers while removing it from the UI.

## Key Changes
- **Removed** the API docs link button from ServerSidebar.vue (the `/llms.txt` link with document icon)
- **Added** semantic link tags in `public/index.html` head:
  - `rel="help"` link pointing to `/llms.txt` for standard help documentation discovery
  - `rel="llms"` link for LLM-specific documentation reference
- **Added** HTML comment in body indicating AI agents should reference `/llms.txt`
- **Updated** test to verify the API docs link no longer renders in the sidebar

## Implementation Details
The LLM documentation is now accessible through standard HTML metadata that can be parsed by AI agents and documentation crawlers, rather than being exposed as a UI element. This approach keeps the sidebar cleaner while maintaining discoverability of API documentation through semantic HTML standards.

https://claude.ai/code/session_01Rx8WU57pmw46aqTKDCtsdP