### PR TITLE
Add CSS styling for linkified URLs in chat messages

### DIFF
--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -3,6 +3,16 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Style links in chat messages to match the app's teal accent */
+.message-link {
+  color: #38a89d;
+  text-decoration: underline;
+}
+
+.message-link:hover {
+  color: #2d8a81;
+}
+
 /* Use dynamic viewport height so the layout accounts for mobile browser chrome */
 @layer utilities {
   .h-screen-safe {

--- a/src/utils/linkify.js
+++ b/src/utils/linkify.js
@@ -11,7 +11,7 @@ function linkify(text) {
   const escaped = escapeHtml(text);
   return escaped.replace(
     /(https?:\/\/[^\s]+)/g,
-    '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>'
+    '<a href="$1" target="_blank" rel="noopener noreferrer" class="message-link">$1</a>'
   );
 }
 

--- a/tests/ChatMessage.test.js
+++ b/tests/ChatMessage.test.js
@@ -163,7 +163,7 @@ describe('ChatMessage.vue', () => {
     });
 
     expect(wrapper.vm.linkedMessage).toBe(
-      'visit <a href="https://example.com" target="_blank" rel="noopener noreferrer">https://example.com</a>'
+      'visit <a href="https://example.com" target="_blank" rel="noopener noreferrer" class="message-link">https://example.com</a>'
     );
   });
 }); 

--- a/tests/linkify.test.js
+++ b/tests/linkify.test.js
@@ -35,26 +35,26 @@ describe('linkify', () => {
 
   test('converts http URL to clickable link', () => {
     expect(linkify('visit http://example.com today')).toBe(
-      'visit <a href="http://example.com" target="_blank" rel="noopener noreferrer">http://example.com</a> today'
+      'visit <a href="http://example.com" target="_blank" rel="noopener noreferrer" class="message-link">http://example.com</a> today'
     );
   });
 
   test('converts https URL to clickable link', () => {
     expect(linkify('check https://example.com/page')).toBe(
-      'check <a href="https://example.com/page" target="_blank" rel="noopener noreferrer">https://example.com/page</a>'
+      'check <a href="https://example.com/page" target="_blank" rel="noopener noreferrer" class="message-link">https://example.com/page</a>'
     );
   });
 
   test('handles URL with path, query, and fragment', () => {
     expect(linkify('see https://example.com/path?q=1&r=2#section')).toBe(
-      'see <a href="https://example.com/path?q=1&amp;r=2#section" target="_blank" rel="noopener noreferrer">https://example.com/path?q=1&amp;r=2#section</a>'
+      'see <a href="https://example.com/path?q=1&amp;r=2#section" target="_blank" rel="noopener noreferrer" class="message-link">https://example.com/path?q=1&amp;r=2#section</a>'
     );
   });
 
   test('handles multiple URLs in one message', () => {
     const result = linkify('visit https://a.com and https://b.com');
     expect(result).toBe(
-      'visit <a href="https://a.com" target="_blank" rel="noopener noreferrer">https://a.com</a> and <a href="https://b.com" target="_blank" rel="noopener noreferrer">https://b.com</a>'
+      'visit <a href="https://a.com" target="_blank" rel="noopener noreferrer" class="message-link">https://a.com</a> and <a href="https://b.com" target="_blank" rel="noopener noreferrer" class="message-link">https://b.com</a>'
     );
   });
 
@@ -67,7 +67,7 @@ describe('linkify', () => {
   test('escapes HTML but still linkifies URLs', () => {
     const result = linkify('<b>bold</b> https://example.com');
     expect(result).toBe(
-      '&lt;b&gt;bold&lt;/b&gt; <a href="https://example.com" target="_blank" rel="noopener noreferrer">https://example.com</a>'
+      '&lt;b&gt;bold&lt;/b&gt; <a href="https://example.com" target="_blank" rel="noopener noreferrer" class="message-link">https://example.com</a>'
     );
   });
 
@@ -79,19 +79,19 @@ describe('linkify', () => {
 
   test('handles URL at start of message', () => {
     expect(linkify('https://example.com is great')).toBe(
-      '<a href="https://example.com" target="_blank" rel="noopener noreferrer">https://example.com</a> is great'
+      '<a href="https://example.com" target="_blank" rel="noopener noreferrer" class="message-link">https://example.com</a> is great'
     );
   });
 
   test('handles URL at end of message', () => {
     expect(linkify('go to https://example.com')).toBe(
-      'go to <a href="https://example.com" target="_blank" rel="noopener noreferrer">https://example.com</a>'
+      'go to <a href="https://example.com" target="_blank" rel="noopener noreferrer" class="message-link">https://example.com</a>'
     );
   });
 
   test('handles message that is only a URL', () => {
     expect(linkify('https://example.com')).toBe(
-      '<a href="https://example.com" target="_blank" rel="noopener noreferrer">https://example.com</a>'
+      '<a href="https://example.com" target="_blank" rel="noopener noreferrer" class="message-link">https://example.com</a>'
     );
   });
 
@@ -101,7 +101,7 @@ describe('linkify', () => {
 
   test('handles URL with port number', () => {
     expect(linkify('http://localhost:3000/test')).toBe(
-      '<a href="http://localhost:3000/test" target="_blank" rel="noopener noreferrer">http://localhost:3000/test</a>'
+      '<a href="http://localhost:3000/test" target="_blank" rel="noopener noreferrer" class="message-link">http://localhost:3000/test</a>'
     );
   });
 


### PR DESCRIPTION
## Summary
This PR adds visual styling to linkified URLs in chat messages by introducing a new `message-link` CSS class that matches the app's teal accent color scheme.

## Changes Made
- **Updated linkify utility** (`src/utils/linkify.js`): Added `class="message-link"` attribute to generated anchor tags
- **Added CSS styling** (`src/assets/styles/main.css`): Created `.message-link` class with:
  - Teal color (#38a89d) matching the app's accent color
  - Underline text decoration for link visibility
  - Darker teal hover state (#2d8a81) for better UX
- **Updated test expectations**: Modified all test cases in `tests/linkify.test.js` and `tests/ChatMessage.test.js` to expect the new class attribute in generated links

## Implementation Details
The styling uses the app's existing teal accent color palette to ensure visual consistency. The hover state provides visual feedback when users interact with links in messages. All existing functionality is preserved—only the styling presentation has been enhanced.

https://claude.ai/code/session_01SSixZm5U2cyZQW4ZvrKgrH