### PR TITLE
Change default channel from 'general' to 'welcome'

### DIFF
--- a/src/components/ChatLayout.vue
+++ b/src/components/ChatLayout.vue
@@ -60,12 +60,12 @@ export default {
       username = 'User_' + Math.floor(Math.random() * 1000);
       try { localStorage.setItem('nilo_username', username); } catch (e) { /* storage unavailable */ }
     }
-    // Get current channel from localStorage or default to general
+    // Get current channel from localStorage or default to welcome
     let savedChannel;
     try {
-      savedChannel = localStorage.getItem('nilo_channel') || 'general';
+      savedChannel = localStorage.getItem('nilo_channel') || 'welcome';
     } catch (e) {
-      savedChannel = 'general';
+      savedChannel = 'welcome';
     }
     // Check if this is the first time joining
     let isFirstJoin;

--- a/src/components/MainSidebar.vue
+++ b/src/components/MainSidebar.vue
@@ -82,7 +82,7 @@ export default {
     },
     currentChannel: {
       type: String,
-      default: 'general'
+      default: 'welcome'
     },
     channelUnreadCounts: {
       type: Object,

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -109,7 +109,7 @@ function setupSocketHandlers(io) {
     // Handle user joining
     socket.on('user_connected', async (data) => {
       username = data.username;
-      const channel = data.channel || 'general';
+      const channel = data.channel || 'welcome';
 
       socket.join(channel);
       await sendMessageHistory(socket, channel);
@@ -117,7 +117,7 @@ function setupSocketHandlers(io) {
 
     // Handle channel change
     socket.on('join_channel', async (data) => {
-      const newChannel = data.channel || 'general';
+      const newChannel = data.channel || 'welcome';
 
       // Leave all channels
       CHANNELS.forEach(channel => {
@@ -145,7 +145,7 @@ function setupSocketHandlers(io) {
       }
 
       const timestamp = new Date().toISOString();
-      const channel = data.channel || 'general';
+      const channel = data.channel || 'welcome';
 
       // Save message to database
       try {

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -252,7 +252,7 @@ describe('Server Module - Comprehensive', () => {
         expect.any(String), // timestamp
         messageData.username,
         messageData.message,
-        'general' // default channel
+        'welcome' // default channel
       ])
     );
 
@@ -426,12 +426,12 @@ describe('Server Module - Comprehensive', () => {
     // Test join_channel with no channel specified
     await handlers.join_channel({});
     expect(socket.leave).toHaveBeenCalled();
-    expect(socket.join).toHaveBeenCalledWith('general');
+    expect(socket.join).toHaveBeenCalledWith('welcome');
 
     // Test user_connected with no channel specified
     socket.join.mockClear();
     await handlers.user_connected({ username: 'testuser' });
-    expect(socket.join).toHaveBeenCalledWith('general');
+    expect(socket.join).toHaveBeenCalledWith('welcome');
 
     // Test chat_message with no channel specified
     await handlers.chat_message({ username: 'testuser', message: 'hello' });


### PR DESCRIPTION
## Summary
This PR updates the default channel across the application from 'general' to 'welcome'. This change affects the client-side initialization, server-side socket handlers, component defaults, and corresponding test cases.

## Key Changes
- **ChatLayout.vue**: Updated localStorage fallback and default channel from 'general' to 'welcome' in the mounted hook
- **Server socket handlers** (index.js): Changed default channel in three socket event handlers:
  - `user_connected`: Default channel when user joins
  - `join_channel`: Default channel when switching channels
  - `chat_message`: Default channel for message routing
- **MainSidebar.vue**: Updated component prop default from 'general' to 'welcome'
- **Tests** (server.test.js): Updated test expectations to reflect the new 'welcome' default channel

## Implementation Details
The change is consistent across all layers of the application:
- Client-side state management defaults to 'welcome'
- Server-side fallbacks use 'welcome' as the default
- Component defaults align with the new convention
- All related tests have been updated to verify the new behavior

https://claude.ai/code/session_01ChS1riyEwv84RVsgrpUjK2