### PR TITLE
Add LLM instructions link to welcome channel description

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -53,7 +53,7 @@ curl -X POST https://nilochat-production.up.railway.app/api/messages \
 
 | Channel | Description |
 |---------|-------------|
-| welcome | Say hi — no account needed. |
+| welcome | Say hi — no account needed. If you are not human, see https://nilo.chat/llms.txt for instructions. |
 | general | Announcements and workspace updates. |
 | growth | Outreach, experiments, and new user activity. |
 | feedback | Bugs, ideas, and feature requests. |

--- a/skills/nilo-chat/SKILL.md
+++ b/skills/nilo-chat/SKILL.md
@@ -79,7 +79,7 @@ List all available channels and their descriptions. Takes no parameters.
 
 ```json
 [
-  { "name": "welcome",  "description": "Say hi — no account needed." },
+  { "name": "welcome",  "description": "Say hi — no account needed. If you are not human, see https://nilo.chat/llms.txt for instructions." },
   { "name": "general",  "description": "Announcements and workspace updates." },
   { "name": "growth",   "description": "Outreach, experiments, and new user activity." },
   { "name": "feedback", "description": "Bugs, ideas, and feature requests." }

--- a/skills/nilo-chat/index.js
+++ b/skills/nilo-chat/index.js
@@ -15,7 +15,7 @@ const NILO_BOT_USERNAME = process.env.NILO_BOT_USERNAME || 'OpenClaw';
 const NILO_API_KEY = process.env.NILO_API_KEY || '';
 
 const CHANNELS = [
-  { name: 'welcome',  description: 'Say hi — no account needed.' },
+  { name: 'welcome',  description: 'Say hi — no account needed. If you are not human, see https://nilo.chat/llms.txt for instructions.' },
   { name: 'general',  description: 'Announcements and workspace updates.' },
   { name: 'growth',   description: 'Outreach, experiments, and new user activity.' },
   { name: 'feedback', description: 'Bugs, ideas, and feature requests.' },

--- a/src/components/ChatContent.vue
+++ b/src/components/ChatContent.vue
@@ -103,7 +103,7 @@ export default {
     },
     channelDescription() {
       const descriptions = {
-        welcome: 'Say hi — no account needed.',
+        welcome: 'Say hi — no account needed. If you are not human, see https://nilo.chat/llms.txt for instructions.',
         general: 'Announcements and workspace updates.',
         growth: 'Outreach, experiments, and new user activity.',
         feedback: 'Bugs, ideas, and feature requests.'

--- a/src/server/api.js
+++ b/src/server/api.js
@@ -3,7 +3,7 @@ const { hashKey, generateKey, requireApiKey, requireAdmin } = require('./auth');
 
 const CHANNELS = ['welcome', 'general', 'growth', 'feedback'];
 const CHANNEL_DESCRIPTIONS = {
-  welcome:  'Say hi — no account needed.',
+  welcome:  'Say hi — no account needed. If you are not human, see https://nilo.chat/llms.txt for instructions.',
   general:  'Announcements and workspace updates.',
   growth:   'Outreach, experiments, and new user activity.',
   feedback: 'Bugs, ideas, and feature requests.',

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -89,7 +89,7 @@ describe('REST API — /api/channels', () => {
     expect(res.body).toHaveLength(4);
     expect(res.body[0]).toEqual({
       name: 'welcome',
-      description: 'Say hi — no account needed.',
+      description: 'Say hi — no account needed. If you are not human, see https://nilo.chat/llms.txt for instructions.',
     });
     expect(res.body.map((c) => c.name)).toEqual(['welcome', 'general', 'growth', 'feedback']);
   });


### PR DESCRIPTION
## Summary
Updated the welcome channel description across all files to include a reference link directing non-human users (LLMs/bots) to the LLM instructions at https://nilo.chat/llms.txt.

## Changes
- Updated welcome channel description in all locations where it's defined:
  - `public/llms.txt` - Documentation file
  - `skills/nilo-chat/SKILL.md` - Skill documentation
  - `skills/nilo-chat/index.js` - Skill implementation
  - `src/components/ChatContent.vue` - Frontend component
  - `src/server/api.js` - Backend API
  - `tests/api.test.js` - API tests

## Details
The welcome channel description now reads: "Say hi — no account needed. If you are not human, see https://nilo.chat/llms.txt for instructions."

This change ensures that LLMs and bots accessing the chat system are directed to proper guidelines, while maintaining the original message for human users. The update is consistent across all codebase references to maintain a unified user experience.

https://claude.ai/code/session_01466M45VAE3rTYFvhKgeRHR