### PR TITLE
Add @mention highlighting and autocomplete completion handling

### DIFF
--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -13,6 +13,15 @@
   color: #2d8a81;
 }
 
+/* Highlight @mentions like Slack/Discord */
+.mention-highlight {
+  background-color: #e0e7ff;
+  color: #4338ca;
+  font-weight: 600;
+  padding: 1px 4px;
+  border-radius: 4px;
+}
+
 /* Use dynamic viewport height so the layout accounts for mobile browser chrome */
 @layer utilities {
   .h-screen-safe {

--- a/src/components/ChatContent.vue
+++ b/src/components/ChatContent.vue
@@ -112,7 +112,8 @@ export default {
       activeUsers: [],
       showAutocomplete: false,
       mentionQuery: '',
-      mentionStartIndex: -1
+      mentionStartIndex: -1,
+      justCompletedMention: false
     }
   },
   computed: {
@@ -263,6 +264,10 @@ export default {
   },
   methods: {
     sendMessage() {
+      if (this.justCompletedMention) {
+        this.justCompletedMention = false;
+        return;
+      }
       if (this.newMessage.trim() === '') return;
 
       if (!this.isConnected) {
@@ -391,6 +396,7 @@ export default {
         autocomplete.moveDown();
       } else if (event.key === 'Tab' || (event.key === 'Enter' && this.showAutocomplete)) {
         event.preventDefault();
+        this.justCompletedMention = true;
         autocomplete.confirmSelection();
       } else if (event.key === 'Escape') {
         this.showAutocomplete = false;

--- a/src/utils/linkify.js
+++ b/src/utils/linkify.js
@@ -9,9 +9,13 @@ function escapeHtml(text) {
 
 function linkify(text) {
   const escaped = escapeHtml(text);
-  return escaped.replace(
+  const linked = escaped.replace(
     /(https?:\/\/[^\s]+)/g,
     '<a href="$1" target="_blank" rel="noopener noreferrer" class="message-link">$1</a>'
+  );
+  return linked.replace(
+    /(^|\s)(@\w+)/g,
+    '$1<span class="mention-highlight">$2</span>'
   );
 }
 

--- a/tests/ChatContent.test.js
+++ b/tests/ChatContent.test.js
@@ -1097,6 +1097,61 @@ describe('ChatContent.vue', () => {
     expect(mockConfirm).toHaveBeenCalled();
   });
 
+  test('handleKeydown Enter sets justCompletedMention flag to prevent sending', () => {
+    const signedInWrapper = shallowMount(ChatContent, {
+      propsData: { username: 'testuser', isSignedIn: true }
+    });
+    signedInWrapper.setData({ showAutocomplete: true });
+    const mockConfirm = jest.fn();
+    signedInWrapper.vm.getAutocompleteRef = () => ({ moveUp: jest.fn(), moveDown: jest.fn(), confirmSelection: mockConfirm });
+    const event = { key: 'Enter', preventDefault: jest.fn() };
+    signedInWrapper.vm.handleKeydown(event);
+    expect(signedInWrapper.vm.justCompletedMention).toBe(true);
+  });
+
+  test('handleKeydown Tab sets justCompletedMention flag to prevent sending', () => {
+    const signedInWrapper = shallowMount(ChatContent, {
+      propsData: { username: 'testuser', isSignedIn: true }
+    });
+    signedInWrapper.setData({ showAutocomplete: true });
+    const mockConfirm = jest.fn();
+    signedInWrapper.vm.getAutocompleteRef = () => ({ moveUp: jest.fn(), moveDown: jest.fn(), confirmSelection: mockConfirm });
+    const event = { key: 'Tab', preventDefault: jest.fn() };
+    signedInWrapper.vm.handleKeydown(event);
+    expect(signedInWrapper.vm.justCompletedMention).toBe(true);
+  });
+
+  test('sendMessage skips sending when justCompletedMention is true', () => {
+    const signedInWrapper = shallowMount(ChatContent, {
+      propsData: { username: 'testuser', isSignedIn: true }
+    });
+    signedInWrapper.setData({
+      newMessage: '@alice hello',
+      justCompletedMention: true,
+      isConnected: true
+    });
+    signedInWrapper.vm.sendMessage();
+    expect(mockSocketEmit).not.toHaveBeenCalledWith('chat_message', expect.anything());
+    expect(signedInWrapper.vm.justCompletedMention).toBe(false);
+    // Message should still be in the input (not cleared)
+    expect(signedInWrapper.vm.newMessage).toBe('@alice hello');
+  });
+
+  test('sendMessage sends normally when justCompletedMention is false', () => {
+    const signedInWrapper = shallowMount(ChatContent, {
+      propsData: { username: 'testuser', isSignedIn: true }
+    });
+    signedInWrapper.setData({
+      newMessage: '@alice hello',
+      justCompletedMention: false,
+      isConnected: true
+    });
+    signedInWrapper.vm.sendMessage();
+    expect(mockSocketEmit).toHaveBeenCalledWith('chat_message', expect.objectContaining({
+      message: '@alice hello'
+    }));
+  });
+
   test('handleKeydown Escape hides autocomplete', () => {
     const signedInWrapper = shallowMount(ChatContent, {
       propsData: { username: 'testuser', isSignedIn: true }

--- a/tests/ChatMessage.test.js
+++ b/tests/ChatMessage.test.js
@@ -166,4 +166,28 @@ describe('ChatMessage.vue', () => {
       'visit <a href="https://example.com" target="_blank" rel="noopener noreferrer" class="message-link">https://example.com</a>'
     );
   });
-}); 
+
+  test('renders @mentions with highlight styling', () => {
+    const wrapper = shallowMount(ChatMessage, {
+      propsData: {
+        ...defaultProps,
+        message: 'hey @alice check this'
+      }
+    });
+
+    const messageEl = wrapper.find('.text-black');
+    expect(messageEl.html()).toContain('<span class="mention-highlight">@alice</span>');
+  });
+
+  test('renders multiple @mentions with highlight styling', () => {
+    const wrapper = shallowMount(ChatMessage, {
+      propsData: {
+        ...defaultProps,
+        message: '@alice and @bob'
+      }
+    });
+
+    expect(wrapper.vm.linkedMessage).toContain('<span class="mention-highlight">@alice</span>');
+    expect(wrapper.vm.linkedMessage).toContain('<span class="mention-highlight">@bob</span>');
+  });
+});

--- a/tests/linkify.test.js
+++ b/tests/linkify.test.js
@@ -108,4 +108,38 @@ describe('linkify', () => {
   test('handles empty string', () => {
     expect(linkify('')).toBe('');
   });
+
+  test('highlights @mention at start of message', () => {
+    expect(linkify('@alice hello')).toBe(
+      '<span class="mention-highlight">@alice</span> hello'
+    );
+  });
+
+  test('highlights @mention in middle of message', () => {
+    expect(linkify('hey @bob check this')).toBe(
+      'hey <span class="mention-highlight">@bob</span> check this'
+    );
+  });
+
+  test('highlights multiple @mentions', () => {
+    expect(linkify('@alice and @bob')).toBe(
+      '<span class="mention-highlight">@alice</span> and <span class="mention-highlight">@bob</span>'
+    );
+  });
+
+  test('highlights @mention alongside a URL', () => {
+    expect(linkify('@alice check https://example.com')).toBe(
+      '<span class="mention-highlight">@alice</span> check <a href="https://example.com" target="_blank" rel="noopener noreferrer" class="message-link">https://example.com</a>'
+    );
+  });
+
+  test('does not highlight @ without username', () => {
+    expect(linkify('email me @ noon')).toBe('email me @ noon');
+  });
+
+  test('highlights @mention at end of message', () => {
+    expect(linkify('hello @charlie')).toBe(
+      'hello <span class="mention-highlight">@charlie</span>'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
This PR adds visual highlighting for @mentions in chat messages and improves the mention autocomplete experience by preventing accidental message sends immediately after completing a mention.

## Key Changes
- **@Mention Highlighting**: Added CSS styling and linkify logic to highlight @mentions with a distinctive background color and styling, similar to Slack/Discord
- **Autocomplete Completion Flag**: Introduced `justCompletedMention` flag to prevent sending messages when Enter or Tab is pressed to complete a mention autocomplete selection
- **Message Send Logic**: Updated `sendMessage()` to skip sending and reset the flag when a mention was just completed, allowing users to continue typing after autocomplete confirmation
- **Linkify Enhancement**: Extended the linkify utility to detect and wrap @mentions in highlight spans alongside existing URL linkification

## Implementation Details
- The `justCompletedMention` flag is set to `true` when Tab or Enter is pressed with autocomplete visible
- On the next `sendMessage()` call, if the flag is true, the send is skipped and the flag is reset, preserving the message text
- @mention regex pattern `/(^|\s)(@\w+)/g` matches mentions at the start or after whitespace
- CSS styling uses indigo colors (#e0e7ff background, #4338ca text) with rounded corners and padding for visual consistency
- All changes are covered by comprehensive unit tests for both the mention highlighting and autocomplete behavior

https://claude.ai/code/session_01Bj91jLVGnnsUSCR2RF3JFx