### PR TITLE
Add Nilo logo to favicon and server sidebar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
   <meta name="description" content="A self improving chat application, built by AI agents">
   <link
     rel="icon"
-    href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 64 64%22><rect width=%2264%22 height=%2264%22 rx=%2214%22 fill=%22%232C3A6E%22/><polyline points=%2222,44 22,20 42,44 42,20%22 fill=%22none%22 stroke=%22%2338A89D%22 stroke-width=%226.5%22 stroke-linecap=%22round%22 stroke-linejoin=%22round%22/></svg>"
+    href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 64 64%22><rect width=%2264%22 height=%2264%22 rx=%2214%22 fill=%22%232f365f%22/><polyline points=%2222,44 22,20 42,44 42,20%22 fill=%22none%22 stroke=%22%2338A89D%22 stroke-width=%226.5%22 stroke-linecap=%22round%22 stroke-linejoin=%22round%22/></svg>"
   >
   <!-- LLM documentation links -->
   <link rel="help" type="text/plain" href="/llms.txt" title="LLM API Documentation">

--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
   <meta name="description" content="A self improving chat application, built by AI agents">
   <link
     rel="icon"
-    href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>💬</text></svg>"
+    href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 64 64%22><rect width=%2264%22 height=%2264%22 rx=%2214%22 fill=%22%231A2140%22/><polyline points=%2222,44 22,20 42,44 42,20%22 fill=%22none%22 stroke=%22%2338A89D%22 stroke-width=%226.5%22 stroke-linecap=%22round%22 stroke-linejoin=%22round%22/></svg>"
   >
   <!-- LLM documentation links -->
   <link rel="help" type="text/plain" href="/llms.txt" title="LLM API Documentation">

--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
   <meta name="description" content="A self improving chat application, built by AI agents">
   <link
     rel="icon"
-    href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 64 64%22><rect width=%2264%22 height=%2264%22 rx=%2214%22 fill=%22%231A2140%22/><polyline points=%2222,44 22,20 42,44 42,20%22 fill=%22none%22 stroke=%22%2338A89D%22 stroke-width=%226.5%22 stroke-linecap=%22round%22 stroke-linejoin=%22round%22/></svg>"
+    href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 64 64%22><rect width=%2264%22 height=%2264%22 rx=%2214%22 fill=%22%232C3A6E%22/><polyline points=%2222,44 22,20 42,44 42,20%22 fill=%22none%22 stroke=%22%2338A89D%22 stroke-width=%226.5%22 stroke-linecap=%22round%22 stroke-linejoin=%22round%22/></svg>"
   >
   <!-- LLM documentation links -->
   <link rel="help" type="text/plain" href="/llms.txt" title="LLM API Documentation">

--- a/src/components/ServerSidebar.vue
+++ b/src/components/ServerSidebar.vue
@@ -2,8 +2,12 @@
   <div class="bg-indigo-darkest text-purple-lighter flex-none w-24 p-6 hidden md:flex md:flex-col">
     <div class="flex-1">
       <div class="cursor-pointer mb-4 relative" @click="switchChannel('general')">
-        <div class="bg-indigo-lighter opacity-25 h-12 w-12 flex items-center justify-center text-black text-2xl font-semibold rounded-lg mb-1 overflow-hidden">
-          N
+        <div class="nilo-logo h-12 w-12 flex items-center justify-center rounded-lg mb-1 overflow-hidden">
+          <svg class="h-12 w-12 block" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <rect width="64" height="64" rx="14" fill="#1A2140" />
+            <polyline points="22,44 22,20 42,44 42,20" fill="none"
+              stroke="#38A89D" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
         </div>
         <div class="text-center text-white opacity-50 text-sm">&#8984;1</div>
         <div v-if="getUnreadCount('general') > 0" class="absolute -top-1 -right-1">

--- a/src/components/ServerSidebar.vue
+++ b/src/components/ServerSidebar.vue
@@ -4,7 +4,7 @@
       <div class="cursor-pointer mb-4 relative" @click="switchChannel('general')">
         <div class="nilo-logo h-12 w-12 flex items-center justify-center rounded-lg mb-1 overflow-hidden">
           <svg class="h-12 w-12 block" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <rect width="64" height="64" rx="14" fill="#1A2140" />
+            <rect width="64" height="64" rx="14" fill="#2C3A6E" />
             <polyline points="22,44 22,20 42,44 42,20" fill="none"
               stroke="#38A89D" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" />
           </svg>

--- a/src/components/ServerSidebar.vue
+++ b/src/components/ServerSidebar.vue
@@ -4,7 +4,7 @@
       <div class="cursor-pointer mb-4 relative" @click="switchChannel('general')">
         <div class="nilo-logo h-12 w-12 flex items-center justify-center rounded-lg mb-1 overflow-hidden">
           <svg class="h-12 w-12 block" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <rect width="64" height="64" rx="14" fill="#2C3A6E" />
+            <rect width="64" height="64" rx="14" fill="#2f365f" />
             <polyline points="22,44 22,20 42,44 42,20" fill="none"
               stroke="#38A89D" stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round" />
           </svg>

--- a/tests/ServerSidebar.test.js
+++ b/tests/ServerSidebar.test.js
@@ -20,9 +20,11 @@ describe('ServerSidebar.vue', () => {
     const logoDiv = wrapper.find('.cursor-pointer.mb-4');
     expect(logoDiv.exists()).toBe(true);
     
-    const logoContent = logoDiv.find('.bg-indigo-lighter');
+    const logoContent = logoDiv.find('.nilo-logo');
     expect(logoContent.exists()).toBe(true);
-    expect(logoContent.text()).toBe('N');
+    const logoSvg = logoContent.find('svg');
+    expect(logoSvg.exists()).toBe(true);
+    expect(logoSvg.find('polyline').exists()).toBe(true);
     
     // Check GitHub link
     const githubLink = wrapper.find('a[href="https://github.com/super3/nilo.chat"]');


### PR DESCRIPTION
## Summary
- Replaces the plain text "N" in the top-left server sidebar with the new Nilo logo SVG (dark rounded square `#1A2140` with a teal `#38A89D` "N" polyline mark).
- Updates the browser favicon from the chat-bubble emoji (💬) to the same Nilo logo, encoded as an inline SVG data URI.

## Changes
- `src/components/ServerSidebar.vue` — swap the `N` text for the inline logo SVG (React attribute names converted to HTML kebab-case, e.g. `stroke-width`).
- `public/index.html` — favicon now uses the Nilo logo SVG.
- `tests/ServerSidebar.test.js` — updated the logo assertion to check for the rendered SVG/polyline instead of the `N` text.

## Testing
- `npx jest` — all 314 tests pass with 100% coverage.

https://claude.ai/code/session_01VLbuH5pwsiN2Yuc4bf32W7

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLbuH5pwsiN2Yuc4bf32W7)_