### PR TITLE
Fix chat not loading: don't gate server startup on DB migrations

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
     "buildCommand": "npm run build"
   },
   "deploy": {
-    "startCommand": "npm run migrate && node src/server/index.js",
+    "startCommand": "node src/server/index.js",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10,
     "healthcheckPath": "/health",


### PR DESCRIPTION
## Problem

`nilo.chat` chats stopped loading with a browser error:

```
Access to XMLHttpRequest at 'https://nilochat-production.up.railway.app/socket.io/...'
from origin 'https://nilo.chat' has been blocked by CORS policy:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
net::ERR_FAILED
```

**This is not actually a CORS misconfiguration.** The server's CORS allowlist in `src/server/index.js` correctly includes `https://nilo.chat` and has never changed. The error is the signature of the **backend being down**: when the Railway app isn't running, the edge returns an error page with no CORS headers, which the browser reports as a CORS failure.

## Root cause

Commit `2a78672` changed the Railway `startCommand`:

```diff
- "startCommand": "node src/server/index.js"
+ "startCommand": "npm run migrate && node src/server/index.js"
```

`migrate.js` calls `process.exit(1)` on **any** error (a transient DB connection blip, a migration issue, etc.). The `&&` then short-circuits and `node src/server/index.js` **never runs** — so the whole HTTP/Socket.IO server stays down. That's why it "was working before": the gate was introduced recently.

## Fix

Drop the migration gate from the start command:

```diff
- "startCommand": "npm run migrate && node src/server/index.js"
+ "startCommand": "node src/server/index.js"
```

This is safe and resilient:

- `initializeDatabase()` in `src/server/index.js` already creates every table, index, and column idempotently (`CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`) and **catches DB errors so the server still starts**.
- Migrations `001`/`002` only duplicate that schema; `003` is a cosmetic one-time backdate of seed rows that the file itself documents as "a harmless no-op" in production.
- The project had already deliberately removed migrations from startup once (commit `2f1e416`); this restores that intent. Migrations remain runnable manually via `npm run migrate`.

## Testing

- `npx jest` — 328 tests pass, 100% coverage maintained.

https://claude.ai/code/session_01SSsH1gUSs25yUKPRedWkcj

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSsH1gUSs25yUKPRedWkcj)_